### PR TITLE
Feature/JPA entity 생성

### DIFF
--- a/src/main/java/com/ODG/ODG_back/domain/Meeting.java
+++ b/src/main/java/com/ODG/ODG_back/domain/Meeting.java
@@ -1,0 +1,35 @@
+package com.ODG.ODG_back.domain;
+
+import com.ODG.ODG_back.domain.enums.MeetingType;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+public class Meeting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private MeetingType type;
+
+    private String inviteCode;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime expiresAt;
+
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
+    private List<Participant> participants;
+
+    @OneToMany(mappedBy = "meeting")
+    private List<Vote> votes;
+
+    @OneToMany(mappedBy = "meeting")
+    private List<RecommendedMidpoint> recommendedMidpoints;
+}

--- a/src/main/java/com/ODG/ODG_back/domain/Midpoint.java
+++ b/src/main/java/com/ODG/ODG_back/domain/Midpoint.java
@@ -1,0 +1,28 @@
+package com.ODG.ODG_back.domain;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Entity
+public class Midpoint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String line;
+
+    private BigDecimal latitude;
+
+    private BigDecimal longitude;
+
+    @OneToMany(mappedBy = "midpoint")
+    private List<RecommendedMidpoint> recommendedMidpoints;
+
+    @ManyToMany(mappedBy = "midpoints")
+    private List<Place> places;
+}

--- a/src/main/java/com/ODG/ODG_back/domain/Participant.java
+++ b/src/main/java/com/ODG/ODG_back/domain/Participant.java
@@ -1,0 +1,27 @@
+package com.ODG.ODG_back.domain;
+
+import com.ODG.ODG_back.domain.enums.TransportType;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class Participant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    private TransportType transport;
+
+    private LocalDateTime joinedAt;
+
+    @ManyToOne
+    private Meeting meeting;
+}

--- a/src/main/java/com/ODG/ODG_back/domain/Place.java
+++ b/src/main/java/com/ODG/ODG_back/domain/Place.java
@@ -1,0 +1,27 @@
+package com.ODG.ODG_back.domain;
+
+import com.ODG.ODG_back.domain.enums.PlaceCategory;
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Entity
+public class Place {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private PlaceCategory category;
+
+    private BigDecimal latitude;
+
+    private BigDecimal longitude;
+
+    @ManyToMany
+    private List<Midpoint> midpoints;
+}

--- a/src/main/java/com/ODG/ODG_back/domain/RecommendedMidpoint.java
+++ b/src/main/java/com/ODG/ODG_back/domain/RecommendedMidpoint.java
@@ -1,0 +1,25 @@
+package com.ODG.ODG_back.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class RecommendedMidpoint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private double score;
+
+    private int rank;
+
+    private LocalDateTime recommendedAt;
+
+    @ManyToOne
+    private Meeting meeting;
+
+    @ManyToOne
+    private Midpoint midpoint;
+}

--- a/src/main/java/com/ODG/ODG_back/domain/Vote.java
+++ b/src/main/java/com/ODG/ODG_back/domain/Vote.java
@@ -1,0 +1,27 @@
+package com.ODG.ODG_back.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class Vote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer voteValue;
+
+    private LocalDateTime votedAt;
+
+    @ManyToOne
+    private Meeting meeting;
+
+    @ManyToOne
+    private Place place;
+
+    @ManyToOne
+    private Participant participant;
+}
+

--- a/src/main/java/com/ODG/ODG_back/domain/enums/MeetingType.java
+++ b/src/main/java/com/ODG/ODG_back/domain/enums/MeetingType.java
@@ -1,0 +1,6 @@
+package com.ODG.ODG_back.domain.enums;
+
+public enum MeetingType {
+    SOCIAL,
+    PROJECT
+}

--- a/src/main/java/com/ODG/ODG_back/domain/enums/PlaceCategory.java
+++ b/src/main/java/com/ODG/ODG_back/domain/enums/PlaceCategory.java
@@ -1,0 +1,9 @@
+package com.ODG.ODG_back.domain.enums;
+
+public enum PlaceCategory {
+    RESTAURANT,
+    ENTERTAINMENT,
+    CAFE,
+    LOUNGE,
+    STUDY_CAFE
+}

--- a/src/main/java/com/ODG/ODG_back/domain/enums/TransportType.java
+++ b/src/main/java/com/ODG/ODG_back/domain/enums/TransportType.java
@@ -1,0 +1,6 @@
+package com.ODG.ODG_back.domain.enums;
+
+public enum TransportType {
+    PUBLIC,
+    CAR
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=wheretogo-back

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+
+spring:
+  application:
+    name: ODG-back
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/odg?useSSL=false&serverTimezone=UTC
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+server:
+  port: 8081

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,8 @@ spring:
 
   datasource:
     url: jdbc:mysql://localhost:3306/odg?useSSL=false&serverTimezone=UTC
-    username: root
-    password: 1234
+    username:
+    password:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -16,5 +16,4 @@ spring:
     properties:
       hibernate:
         format_sql: true
-server:
-  port: 8081
+


### PR DESCRIPTION
## 선 요약
- DB schema에 따라 주요 테이블들을 JPA entity로 생성
- mySQL 연결을 위한 application.yml 생성

## 내용
DB diagram에서 쓴 스키마에 기반하여 Meeting, Participant, Place, Midpoint, RecommendedMidpoint, Vote JPA entity를 생성했습니다. 지하철 DB는 지금 단계에서 하는 것이 조금 아닌 듯하여 일단 구현하지 않았습니다. 

MySQL은 community version 8.0.42 설치하였고, 자세한 설치 방법은 인터넷 참고하시길 바랍니다. (제가 참고한 자료 https://it-learner.tistory.com/27)
application.properties로 설정을 하는 것은 쓰는 것도 불편하고 계층 구조가 한눈에 들어오지 않아서 yml 파일로 설정을 작성하였습니다. `datasource`의 `url`은 `odg`자리에 본인이 생성한 DB 명을 적으면 되고, `username`은 본인이 설정한 아이디, `password`는 본인이 설정한 비밀번호를 적으면 mySQL에 연결됩니다. 
다음 코드를 통해 로컬에서 origin에 있는 branch 목록을 갱신시키고 `feature/create-entity` branch로 checkout해서 코드를 실행시켜 볼 수 있습니다. 
```
git fetch origin
git checkout feature/create-entity
```
