### PR TITLE
Feature/ 후보 장소 조회 API 구현

### DIFF
--- a/src/main/java/com/ODG/ODG_back/controller/PlaceController.java
+++ b/src/main/java/com/ODG/ODG_back/controller/PlaceController.java
@@ -1,4 +1,26 @@
 package com.ODG.ODG_back.controller;
 
+import com.ODG.ODG_back.dto.place.response.PlaceResponseDto;
+import com.ODG.ODG_back.service.PlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/meetings/{inviteCode}")
+@RequiredArgsConstructor
 public class PlaceController {
+
+    private final PlaceService placeService;
+
+    @GetMapping("/places")
+    public ResponseEntity<List<PlaceResponseDto>> getPlacesByMidpoint(@PathVariable String inviteCode) {
+        return ResponseEntity.ok(placeService.getPlacesByMidpoint(inviteCode));
+    }
+
 }

--- a/src/main/java/com/ODG/ODG_back/domain/Meeting.java
+++ b/src/main/java/com/ODG/ODG_back/domain/Meeting.java
@@ -2,11 +2,13 @@ package com.ODG.ODG_back.domain;
 
 import com.ODG.ODG_back.domain.enums.MeetingType;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
+@Getter
 public class Meeting {
 
     @Id

--- a/src/main/java/com/ODG/ODG_back/domain/Place.java
+++ b/src/main/java/com/ODG/ODG_back/domain/Place.java
@@ -2,11 +2,14 @@ package com.ODG.ODG_back.domain;
 
 import com.ODG.ODG_back.domain.enums.PlaceCategory;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.util.List;
 
 @Entity
+@Getter
 public class Place {
 
     @Id

--- a/src/main/java/com/ODG/ODG_back/domain/RecommendedMidpoint.java
+++ b/src/main/java/com/ODG/ODG_back/domain/RecommendedMidpoint.java
@@ -1,10 +1,12 @@
 package com.ODG.ODG_back.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 public class RecommendedMidpoint {
 
     @Id

--- a/src/main/java/com/ODG/ODG_back/domain/enums/MeetingType.java
+++ b/src/main/java/com/ODG/ODG_back/domain/enums/MeetingType.java
@@ -1,6 +1,18 @@
 package com.ODG.ODG_back.domain.enums;
 
+import lombok.Getter;
+
+import java.util.List;
+import static com.ODG.ODG_back.domain.enums.PlaceCategory.*;
+
+@Getter
 public enum MeetingType {
-    SOCIAL,
-    PROJECT
+    SOCIAL(List.of(RESTAURANT, CAFE, ENTERTAINMENT)),
+    PROJECT(List.of(STUDY_CAFE, LOUNGE));
+
+    private final List<PlaceCategory> categories;
+
+    MeetingType(List<PlaceCategory> categories) {
+        this.categories = categories;
+    }
 }

--- a/src/main/java/com/ODG/ODG_back/dto/place/response/PlaceResponseDto.java
+++ b/src/main/java/com/ODG/ODG_back/dto/place/response/PlaceResponseDto.java
@@ -1,0 +1,15 @@
+package com.ODG.ODG_back.dto.place.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class PlaceResponseDto {
+    private Long placeId;
+    private String name;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+}

--- a/src/main/java/com/ODG/ODG_back/dto/place/response/PlaceResponseDto.java
+++ b/src/main/java/com/ODG/ODG_back/dto/place/response/PlaceResponseDto.java
@@ -1,5 +1,6 @@
 package com.ODG.ODG_back.dto.place.response;
 
+import com.ODG.ODG_back.domain.enums.PlaceCategory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,6 +11,7 @@ import java.math.BigDecimal;
 public class PlaceResponseDto {
     private Long placeId;
     private String name;
+    private PlaceCategory category;
     private BigDecimal latitude;
     private BigDecimal longitude;
 }

--- a/src/main/java/com/ODG/ODG_back/mapper/PlaceMapper.java
+++ b/src/main/java/com/ODG/ODG_back/mapper/PlaceMapper.java
@@ -12,7 +12,5 @@ public interface PlaceMapper {
     PlaceMapper INSTANCE = Mappers.getMapper(PlaceMapper.class);
 
     @Mapping(source = "id", target = "placeId")
-    @Mapping(source = "latitude", target = "latitude")
-    @Mapping(source = "longitude", target = "longitude")
     PlaceResponseDto toDto(Place place);
 }

--- a/src/main/java/com/ODG/ODG_back/mapper/PlaceMapper.java
+++ b/src/main/java/com/ODG/ODG_back/mapper/PlaceMapper.java
@@ -1,0 +1,18 @@
+package com.ODG.ODG_back.mapper;
+
+import com.ODG.ODG_back.domain.Place;
+import com.ODG.ODG_back.dto.place.response.PlaceResponseDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface PlaceMapper {
+
+    PlaceMapper INSTANCE = Mappers.getMapper(PlaceMapper.class);
+
+    @Mapping(source = "id", target = "placeId")
+    @Mapping(source = "latitude", target = "latitude")
+    @Mapping(source = "longitude", target = "longitude")
+    PlaceResponseDto toDto(Place place);
+}

--- a/src/main/java/com/ODG/ODG_back/repository/MeetingRepository.java
+++ b/src/main/java/com/ODG/ODG_back/repository/MeetingRepository.java
@@ -4,4 +4,5 @@ import com.ODG.ODG_back.domain.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+    Meeting findByInviteCode(String inviteCode);
 }

--- a/src/main/java/com/ODG/ODG_back/repository/PlaceRepository.java
+++ b/src/main/java/com/ODG/ODG_back/repository/PlaceRepository.java
@@ -1,0 +1,13 @@
+package com.ODG.ODG_back.repository;
+
+import com.ODG.ODG_back.domain.Midpoint;
+import com.ODG.ODG_back.domain.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+
+    List<Place> findByMidpoint(Midpoint midpoint);
+}

--- a/src/main/java/com/ODG/ODG_back/repository/RecommendedMidpointRepository.java
+++ b/src/main/java/com/ODG/ODG_back/repository/RecommendedMidpointRepository.java
@@ -1,7 +1,9 @@
 package com.ODG.ODG_back.repository;
 
+import com.ODG.ODG_back.domain.Meeting;
 import com.ODG.ODG_back.domain.RecommendedMidpoint;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecommendedMidpointRepository extends JpaRepository<RecommendedMidpoint, Long> {
+    RecommendedMidpoint findByMeeting(Meeting meeting);
 }

--- a/src/main/java/com/ODG/ODG_back/service/PlaceService.java
+++ b/src/main/java/com/ODG/ODG_back/service/PlaceService.java
@@ -4,6 +4,8 @@ import com.ODG.ODG_back.domain.Meeting;
 import com.ODG.ODG_back.domain.Midpoint;
 import com.ODG.ODG_back.domain.Place;
 import com.ODG.ODG_back.domain.RecommendedMidpoint;
+import com.ODG.ODG_back.domain.enums.MeetingType;
+import com.ODG.ODG_back.domain.enums.PlaceCategory;
 import com.ODG.ODG_back.dto.place.response.PlaceResponseDto;
 import com.ODG.ODG_back.mapper.PlaceMapper;
 import com.ODG.ODG_back.repository.MeetingRepository;
@@ -28,11 +30,30 @@ public class PlaceService {
         Meeting meeting = meetingRepository.findByInviteCode(inviteCode);
 
         RecommendedMidpoint recommendedMidpoint = recommendedMidpointRepository.findByMeeting(meeting);
-
         Midpoint midpoint = recommendedMidpoint.getMidpoint();
+
         List<Place> places = placeRepository.findByMidpoint(midpoint);
 
+        return switch (meeting.getType()) {
+            case SOCIAL -> filterSocialPlaces(places);
+            case PROJECT -> filterProjectPlaces(places);
+        };
+    }
+    private List<PlaceResponseDto> filterSocialPlaces(List<Place> places) {
         return places.stream()
+                .filter(p -> p.getCategory() == PlaceCategory.RESTAURANT
+                        || p.getCategory() == PlaceCategory.CAFE
+                        || p.getCategory() == PlaceCategory.ENTERTAINMENT
+                )
+                .map(placeMapper::toDto)
+                .toList();
+    }
+
+    private List<PlaceResponseDto> filterProjectPlaces(List<Place> places) {
+        return places.stream()
+                .filter(p -> p.getCategory() == PlaceCategory.LOUNGE
+                        || p.getCategory() == PlaceCategory.STUDY_CAFE
+                )
                 .map(placeMapper::toDto)
                 .toList();
     }

--- a/src/main/java/com/ODG/ODG_back/service/PlaceService.java
+++ b/src/main/java/com/ODG/ODG_back/service/PlaceService.java
@@ -1,0 +1,39 @@
+package com.ODG.ODG_back.service;
+
+import com.ODG.ODG_back.domain.Meeting;
+import com.ODG.ODG_back.domain.Midpoint;
+import com.ODG.ODG_back.domain.Place;
+import com.ODG.ODG_back.domain.RecommendedMidpoint;
+import com.ODG.ODG_back.dto.place.response.PlaceResponseDto;
+import com.ODG.ODG_back.mapper.PlaceMapper;
+import com.ODG.ODG_back.repository.MeetingRepository;
+import com.ODG.ODG_back.repository.PlaceRepository;
+import com.ODG.ODG_back.repository.RecommendedMidpointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceService {
+
+    private final MeetingRepository meetingRepository;
+    private final RecommendedMidpointRepository recommendedMidpointRepository;
+    private final PlaceRepository placeRepository;
+
+    private final PlaceMapper placeMapper;
+
+    public List<PlaceResponseDto> getPlacesByMidpoint(String inviteCode) {
+        Meeting meeting = meetingRepository.findByInviteCode(inviteCode);
+
+        RecommendedMidpoint recommendedMidpoint = recommendedMidpointRepository.findByMeeting(meeting);
+
+        Midpoint midpoint = recommendedMidpoint.getMidpoint();
+        List<Place> places = placeRepository.findByMidpoint(midpoint);
+
+        return places.stream()
+                .map(placeMapper::toDto)
+                .toList();
+    }
+}

--- a/src/main/java/com/ODG/ODG_back/service/PlaceService.java
+++ b/src/main/java/com/ODG/ODG_back/service/PlaceService.java
@@ -34,26 +34,14 @@ public class PlaceService {
 
         List<Place> places = placeRepository.findByMidpoint(midpoint);
 
-        return switch (meeting.getType()) {
-            case SOCIAL -> filterSocialPlaces(places);
-            case PROJECT -> filterProjectPlaces(places);
-        };
-    }
-    private List<PlaceResponseDto> filterSocialPlaces(List<Place> places) {
-        return places.stream()
-                .filter(p -> p.getCategory() == PlaceCategory.RESTAURANT
-                        || p.getCategory() == PlaceCategory.CAFE
-                        || p.getCategory() == PlaceCategory.ENTERTAINMENT
-                )
-                .map(placeMapper::toDto)
-                .toList();
+        return filterPlaces(places, meeting.getType());
     }
 
-    private List<PlaceResponseDto> filterProjectPlaces(List<Place> places) {
+    private List<PlaceResponseDto> filterPlaces(List<Place> places, MeetingType type) {
+        List<PlaceCategory> allowed = type.getCategories();
+
         return places.stream()
-                .filter(p -> p.getCategory() == PlaceCategory.LOUNGE
-                        || p.getCategory() == PlaceCategory.STUDY_CAFE
-                )
+                .filter(p -> allowed.contains(p.getCategory()))
                 .map(placeMapper::toDto)
                 .toList();
     }


### PR DESCRIPTION
### 요약
- 후보 장소 조회(Place) API 구현

### 내용
/meetings/{inviteCode}/places
 - `inviteCode`를 기반으로 해당 모임을 조회
 - 해당 모임에 연관된 `RecommendedMidpoint` 가져옴
 - 해당 `RecommendedMidpoint`의 `Midpoint`에 매핑된 장소 (`Place`) 리스트 조회 후 DTO로 변환

### 참고
- 하나의 중간지점(하나의 `RecommendedMidpoint`)만 사용자에게 제공한다는 점 반영했습니다.
- Map-struct 이용한 `PlaceMapper` 이용해 DTO 변환했습니다.

