### PR TITLE
Feature/Midpoint-Subway 지하철역 기반 중간지점 계산 로직 구현 완료

### DIFF
--- a/src/main/java/com/ODG/ODG_back/domain/Midpoint.java
+++ b/src/main/java/com/ODG/ODG_back/domain/Midpoint.java
@@ -17,19 +17,15 @@ import java.util.List;
 public class Midpoint {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
 
-    private String line;
-
+    @Column(precision = 15, scale = 8)
     private BigDecimal latitude;
 
+    @Column(precision = 15, scale = 8)
     private BigDecimal longitude;
-
-    @OneToMany(mappedBy = "midpoint")
-    private List<RecommendedMidpoint> recommendedMidpoints;
 
     @ManyToMany(mappedBy = "midpoints")
     private List<Place> places;

--- a/src/main/java/com/ODG/ODG_back/domain/SubwayDurationTime.java
+++ b/src/main/java/com/ODG/ODG_back/domain/SubwayDurationTime.java
@@ -1,0 +1,36 @@
+package com.ODG.ODG_back.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(indexes = { @Index(name = "idx_start_end", columnList = "start,end") })
+public class SubwayDurationTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    Long start;
+
+    @Column(nullable = false)
+    Long end;
+
+    int shortestDurationTime; // 최소 소요 시간
+    int transferCountForShortestDuration; // 최소 소요 시간일 때 환승 횟수
+
+    @Column(nullable = false, length = 2000)
+    String shortestDurationTimePath; // 최소 소요 시간일 때 경로
+
+    int durationTimeForMinimumTransfer; // 최소 환승 횟수일 때 소요 시간
+    int minimumTransferCount; // 최소 환승 횟수
+
+    @Column(nullable = false, length = 2000)
+    String minimumTransferPath; // 최소 환승 횟수일 때 경로
+}

--- a/src/main/java/com/ODG/ODG_back/dto/external/OverpassStationInfoDTO.java
+++ b/src/main/java/com/ODG/ODG_back/dto/external/OverpassStationInfoDTO.java
@@ -1,0 +1,4 @@
+package com.ODG.ODG_back.dto.external;
+
+public class OverpassStationInfoDTO {
+}

--- a/src/main/java/com/ODG/ODG_back/external/openStreetMap/OpenStreetMapApiClient.java
+++ b/src/main/java/com/ODG/ODG_back/external/openStreetMap/OpenStreetMapApiClient.java
@@ -1,0 +1,4 @@
+package com.ODG.ODG_back.external.openStreetMap;
+
+public interface OpenStreetMapApiClient {
+}

--- a/src/main/java/com/ODG/ODG_back/external/openStreetMap/OpenStreetMapApiClientImpl.java
+++ b/src/main/java/com/ODG/ODG_back/external/openStreetMap/OpenStreetMapApiClientImpl.java
@@ -1,0 +1,4 @@
+package com.ODG.ODG_back.external.openStreetMap;
+
+public class OpenStreetMapApiClientImpl {
+}

--- a/src/main/java/com/ODG/ODG_back/external/overpass/OverpassApiClient.java
+++ b/src/main/java/com/ODG/ODG_back/external/overpass/OverpassApiClient.java
@@ -1,0 +1,4 @@
+package com.ODG.ODG_back.external.overpass;
+
+public interface OverpassApiClient {
+}

--- a/src/main/java/com/ODG/ODG_back/external/overpass/OverpassApiClientImpl.java
+++ b/src/main/java/com/ODG/ODG_back/external/overpass/OverpassApiClientImpl.java
@@ -1,0 +1,4 @@
+package com.ODG.ODG_back.external.overpass;
+
+public class OverpassApiClientImpl {
+}

--- a/src/main/java/com/ODG/ODG_back/repository/SubwayDurationTimeRepository.java
+++ b/src/main/java/com/ODG/ODG_back/repository/SubwayDurationTimeRepository.java
@@ -1,0 +1,10 @@
+package com.ODG.ODG_back.repository;
+
+import com.ODG.ODG_back.domain.SubwayDurationTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SubwayDurationTimeRepository extends JpaRepository<SubwayDurationTime, Long> {
+   Optional<SubwayDurationTime> findByStartAndEnd(Long start, Long end);
+}

--- a/src/main/java/com/ODG/ODG_back/strategy/SubwayMidpointStrategy.java
+++ b/src/main/java/com/ODG/ODG_back/strategy/SubwayMidpointStrategy.java
@@ -1,17 +1,147 @@
 package com.ODG.ODG_back.strategy;
 
+import com.ODG.ODG_back.domain.*;
+import com.ODG.ODG_back.dto.external.OverpassStationInfoDTO;
 import com.ODG.ODG_back.dto.midpoint.response.MidpointResponseDto;
+import com.ODG.ODG_back.exception.ErrorCode;
+import com.ODG.ODG_back.exception.custom.NotFoundException;
+import com.ODG.ODG_back.external.google.GoogleMatrixApiClient;
+import com.ODG.ODG_back.external.openStreetMap.OpenStreetMapApiClient;
+import com.ODG.ODG_back.external.overpass.OverpassApiClient;
+import com.ODG.ODG_back.mapper.MidpointMapper;
+import com.ODG.ODG_back.repository.MeetingRepository;
+import com.ODG.ODG_back.repository.MidpointRepository;
+import com.ODG.ODG_back.repository.RecommendedMidpointRepository;
+import com.ODG.ODG_back.repository.SubwayDurationTimeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.util.*;
+
+import static java.util.stream.Collectors.groupingBy;
 
 @Component("subwayStrategy")
 @RequiredArgsConstructor
 public class SubwayMidpointStrategy implements MidpointStrategy{
+    private final int MAX_DISTANCE = 2000; // 최대 검색 거리 (미터 단위)
+    private final MeetingRepository meetingRepository;
+    private final RecommendedMidpointRepository recommendedMidpointRepository;
+    private final MidpointRepository midpointRepository;
+    private final MidpointMapper midpointMapper;
+    private final SubwayDurationTimeRepository timeRepository; // 지하철역간 이동 시간 저장소
 
     @Override
     public MidpointResponseDto calculateMidpoints(String inviteCode) {
-        return new MidpointResponseDto(1L, "dummy", BigDecimal.ZERO, BigDecimal.ZERO);
+
+        Meeting meeting = meetingRepository.findByInviteCode(inviteCode).orElseThrow(
+                () -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND)
+        );
+        // 출발지 = 참가자 위치
+        List<Participant> participants = meeting.getParticipants();
+        // 목적지 = 모든 지하철역
+        List<Midpoint> allMidpoints = midpointRepository.findAll();
+
+        // 각 participant별로 allMidpoints에서 가장 가까운 지하철역을 찾아 리스트에 추가
+
+        List<Midpoint> nearestMidpoints = new ArrayList<>();
+        for (Participant participant : participants) {
+            Midpoint nearest = allMidpoints.stream()
+                    .min(Comparator.comparing(midpoint ->
+                            participant.getLatitude().subtract(midpoint.getLatitude()).abs()
+                                    .add(participant.getLongitude().subtract(midpoint.getLongitude()).abs())
+                    ))
+                    .orElseThrow(RuntimeException::new);
+            nearestMidpoints.add(nearest);
+        }
+
+        List<MidpointScore> midpointScores = calculateMidpointScores(nearestMidpoints, allMidpoints, participants.size());
+
+        MidpointScore best = midpointScores.stream()
+                .min(Comparator.comparingDouble(MidpointScore::totalDeviation))
+                .orElseThrow(RuntimeException::new);
+
+        saveRecommendedMidpoint(best, meeting);
+        return midpointMapper.toDto(best.midpoint());
     }
+
+    // 각 참가자별 가장 가까운 역(nearbyStationsForEachParticipant)과 모든 Midpoint의 역 정보를 기반으로
+    // 각 Midpoint까지의 소요 시간 합(midPointScore)을 계산하여 반환하는 메서드
+    public List<MidpointScore> calculateMidpointScores(
+            List<Midpoint> nearbyStationsForEachParticipant,
+            List<Midpoint> allMidpoints,
+            int numberOfParticipants) {
+
+        List<MidpointScore> scores = new ArrayList<>();
+
+        for (Midpoint midpoint : allMidpoints) {
+            var score = calculateMidpointScore(nearbyStationsForEachParticipant, numberOfParticipants, midpoint);
+
+            if(score != null) {
+                scores.add(score);
+            }
+        }
+
+        return scores;
+    }
+
+    public MidpointScore calculateMidpointScore(List<Midpoint> nearbyStationsForEachParticipant, int numberOfParticipants, Midpoint midpoint) {
+        int totalDuration = 0;
+
+        try{
+
+            for (Midpoint startStation : nearbyStationsForEachParticipant) {
+                // 시작역과 목적지역 이름이 모두 존재해야 함
+
+                // SubwayDurationTimeRepository에서 소요 시간 조회
+                SubwayDurationTime durationOpt = getDurationInfo(startStation, midpoint);
+                totalDuration += durationOpt.getShortestDurationTime();
+
+                return new MidpointScore(midpoint, (double) totalDuration / numberOfParticipants, totalDuration);
+            }
+        }
+        catch (NotFoundException e) {
+            // 해당 midpoint에 대한 정보가 없으면 유효하지 않은 것으로 간주
+        }
+
+        return null;
+    }
+
+    public SubwayDurationTime getDurationInfo(
+            Midpoint start,
+            Midpoint end) {
+        // 시작역과 목적지역 이름이 모두 존재해야 함
+
+        if(Objects.equals(start.getId(), end.getId())){
+            new SubwayDurationTime();
+            return SubwayDurationTime.builder()
+                    .start(start.getId())
+                    .end(end.getId())
+                    .shortestDurationTime(0)
+                    .transferCountForShortestDuration(0)
+                    .build();
+        }
+        Optional<SubwayDurationTime> durationTime = timeRepository.findByStartAndEnd(
+                start.getId(), end.getId());
+
+        if (durationTime.isEmpty()) {
+            throw new NotFoundException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        return durationTime.get();
+    }
+
+    private void saveRecommendedMidpoint(MidpointScore best, Meeting meeting) {
+        RecommendedMidpoint recommended = new RecommendedMidpoint(
+                null,
+                best.avg(),
+                1,
+                java.time.LocalDateTime.now(),
+                meeting,
+                best.midpoint()
+        );
+        recommendedMidpointRepository.save(recommended);
+    }
+
+    public record MidpointScore(Midpoint midpoint, double avg, double totalDeviation) {}
 }

--- a/src/test/java/com/ODG/ODG_back/strategy/SubwayMidpointStrategyTest.java
+++ b/src/test/java/com/ODG/ODG_back/strategy/SubwayMidpointStrategyTest.java
@@ -1,0 +1,205 @@
+package com.ODG.ODG_back.strategy;
+import com.ODG.ODG_back.domain.Meeting;
+import com.ODG.ODG_back.domain.Midpoint;
+import com.ODG.ODG_back.domain.Participant;
+import com.ODG.ODG_back.domain.SubwayDurationTime;
+
+import com.ODG.ODG_back.dto.midpoint.response.MidpointResponseDto;
+import com.ODG.ODG_back.mapper.MidpointMapper;
+import com.ODG.ODG_back.repository.*;
+import jakarta.servlet.http.Part;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static com.ODG.ODG_back.domain.enums.TransportType.CAR;
+import static com.ODG.ODG_back.domain.enums.TransportType.PUBLIC;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+//@SpringBootTest
+class SubwayMidpointStrategyTest {
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @Mock
+    private MidpointRepository midpointRepository;
+
+    @Mock
+    private SubwayDurationTimeRepository timeRepository;
+
+    @Mock
+    private RecommendedMidpointRepository recommendedMidpointRepository;
+
+    @Mock
+    private MidpointMapper midpointMapper;
+
+    @InjectMocks
+    private SubwayMidpointStrategy strategy;
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("getDurationInfo DB 연동 통합 테스트")
+    void getDurationInfoIntegrationTest() {
+        // given
+
+        Midpoint m1 = Midpoint.builder().name("강남").id(1002000222L).build();
+        Midpoint m2 = Midpoint.builder().name("역삼").id(1077000687L).build();
+
+        // 실제 DB에 해당 데이터가 있어야 함
+        SubwayDurationTime time = timeRepository.findByStartAndEnd(m1.getId(), m2.getId())
+                .orElseThrow(() -> new RuntimeException("DB에 데이터가 없습니다."));
+
+        System.out.println(time);
+        assert time != null;
+    }
+
+        @Test
+        @DisplayName("calculateMidpointScore 단위 테스트")
+        void calculateMidpointScoreTest() {
+
+            Midpoint m1 = Midpoint.builder().name("강남").id(1002000222L).build();
+            Midpoint m2 = Midpoint.builder().name("역삼").id(1077000687L).build();
+
+            List<Midpoint> participants = List.of(m1, m2);
+
+            // 실제 DB에 m1, m2 간 데이터가 있어야 함
+            Midpoint resultMidpoint = m2;
+            var score = strategy.calculateMidpointScore(participants, participants.size(), resultMidpoint);
+
+            assertNotNull(score);
+            System.out.println("Calculated Score: " + score);
+            assertEquals(7.0, score.totalDeviation(), "Score should be 7.0");
+//            assertTrue(score., "Score should be greater than 0");
+        }
+
+        @Test
+        @DisplayName("calculateMidpointScores 단위 테스트")
+        void calculateMidpointScoresTest() {
+            Midpoint m1 = Midpoint.builder().name("강남").id(1002000222L).build();
+            Midpoint m2 = Midpoint.builder().name("역삼").id(1077000687L).build();
+
+            List<Midpoint> participants = List.of(m1, m2);
+            List<Midpoint> allMidpoints = List.of(m1, m2);
+
+            var scores = strategy.calculateMidpointScores(participants, allMidpoints, participants.size());
+
+            assertNotNull(scores);
+            assertFalse(scores.isEmpty());
+        }
+
+        @Test
+        @DisplayName("getDurationInfo 예외 테스트")
+        void getDurationInfoExceptionTest() {
+            Midpoint m1 = Midpoint.builder().name("없는역1").id(9999999999L).build();
+            Midpoint m2 = Midpoint.builder().name("없는역2").id(8888888888L).build();
+
+            assertThrows(RuntimeException.class, () -> {
+                strategy.getDurationInfo(m1, m2);
+            });
+        }
+
+        @Test
+        @DisplayName("getMidPoint 정상 동작 테스트")
+        void getMidpointTest() {
+            Meeting meeting = new Meeting();
+            meeting.setInviteCode("abc123");
+
+            // 참가자 추가
+            Participant p1 = Participant.builder()
+                    .name("민재")
+                    .transportType(PUBLIC)
+                    .latitude(BigDecimal.valueOf(127.037))
+                    .longitude(BigDecimal.valueOf(33.497)) //역삼 근처
+                    .build();
+            Participant p2 = Participant.builder()
+                    .name("승민")
+                    .transportType(PUBLIC)
+                    .latitude(BigDecimal.valueOf(127.029))
+                    .longitude(BigDecimal.valueOf(33.497)) //강남 근처
+                    .build();
+
+            meeting.setParticipants(List.of(p1, p2));
+
+            when(meetingRepository.findByInviteCode("abc123")).thenReturn(Optional.of(meeting));
+
+            // 후보 중간지점 (Midpoint) 설정
+            Midpoint yeoksam = Midpoint.builder()
+                    .id(1002000222L)
+                    .latitude(BigDecimal.valueOf(127.037))
+                    .longitude(BigDecimal.valueOf(33.497))
+                    .name("역삼")
+                    .build();
+
+            Midpoint gangnam = Midpoint.builder()
+                    .id(1077000687L)
+                    .name("강남")
+                    .latitude(BigDecimal.valueOf(127.029))
+                    .longitude(BigDecimal.valueOf(33.497))
+                    .build();
+
+            when(midpointRepository.findAll()).thenReturn(List.of(yeoksam, gangnam));
+
+            // 지하철 시간 정보 설정
+            SubwayDurationTime gToYTime = new SubwayDurationTime()
+                    .builder()
+                    .start(gangnam.getId())
+                    .end(yeoksam.getId())
+                    .shortestDurationTime(5) // 예시 소요 시간
+                    .build();
+            SubwayDurationTime yToGTime = new SubwayDurationTime()
+                    .builder()
+                    .start(yeoksam.getId())
+                    .end(gangnam.getId())
+                    .shortestDurationTime(10) // 예시 소요 시간
+                    .build();
+
+            SubwayDurationTime samePlaceTime = new SubwayDurationTime()
+                    .builder()
+                    .start(yeoksam.getId())
+                    .end(yeoksam.getId())
+                    .shortestDurationTime(0) // 예시 소요 시간
+                    .build();
+
+            when(timeRepository.findByStartAndEnd(yeoksam.getId(), yeoksam.getId()))
+                    .thenReturn(Optional.of(samePlaceTime)); // 예시 소요 시간
+
+            when(timeRepository.findByStartAndEnd(gangnam.getId(), gangnam.getId()))
+                    .thenReturn(Optional.of(samePlaceTime)); // 예시 소요 시간
+
+            when(timeRepository.findByStartAndEnd(yeoksam.getId(), gangnam.getId()))
+                    .thenReturn(Optional.of(yToGTime)); // 예시 소요 시간
+
+            when(timeRepository.findByStartAndEnd(gangnam.getId(), yeoksam.getId()))
+                    .thenReturn(Optional.of(gToYTime)); // 예시 소요 시간
+
+            when(midpointMapper.toDto(any())).thenAnswer(invocation ->
+            {
+                Midpoint mp = invocation.getArgument(0);
+                return new MidpointResponseDto(mp.getId(), mp.getName(), mp.getLatitude(), mp.getLongitude());
+            });
+
+            MidpointResponseDto result = strategy.calculateMidpoints("abc123");
+            assertEquals("역삼", result.getName());
+        }
+}


### PR DESCRIPTION
## 개요
지하철 기반 중간지점 추천 전략(SubwayMidpointStrategy) 구현
참가자 위치에서 가장 가까운 지하철역을 기준으로, 모든 지하철역까지의 소요시간을 계산하여 최적의 중간지점 추천

## 주요 변경 사항
- SubwayMidpointStrategy 클래스 구현 및 Bean 등록
- 참가자별 가장 가까운 지하철역 탐색 로직 추가
- SubwayDurationTimeRepository를 통한 역간 소요시간 조회 및 예외 처리
- 소요시간 편차가 가장 작은 역을 중간지점으로 선정
- 추천 결과를 RecommendedMidpoint로 저장
- 단위 테스트(SubwayMidpointStrategyTest) 추가 및 Mock 기반 테스트 환경 구성

## 테스트
- 참가자 2명, 2개 역 기준 정상 동작 및 예외 상황 단위 테스트 작성 (강남역 근처, 역삼역 근처 사람들)
- SubwayDurationTimeRepository Mock 데이터로 NPE 및 예외 방지

## 기타
- 통합 테스트와 단위 테스트 환경 분리 (@Mock, @InjectMocks 사용)