### PR TITLE
Feature/swagger

### DIFF
--- a/src/main/java/com/ODG/ODG_back/controller/MeetingController.java
+++ b/src/main/java/com/ODG/ODG_back/controller/MeetingController.java
@@ -4,6 +4,13 @@ import com.ODG.ODG_back.dto.meeting.request.MeetingCreateRequestDto;
 import com.ODG.ODG_back.dto.meeting.response.MeetingCreateResponseDto;
 import com.ODG.ODG_back.dto.meeting.response.MeetingInfoResponseDto;
 import com.ODG.ODG_back.service.MeetingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,16 +18,55 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/meetings")
 @RequiredArgsConstructor
+@Tag(name = "Meeting", description = "모임 관리 API")
 public class MeetingController {
     private final MeetingService meetingService;
 
+    @Operation(
+            summary = "새 모임 생성",
+            description = "새로운 모임을 생성하고 고유한 링크 코드를 발급합니다. " +
+                    "생성된 링크 코드로 참가자들이 모임에 참여할 수 있습니다." +
+                    "인증이 필요하지 않는 공개 API입니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "모임 생성 성공",
+                    content = @Content(schema = @Schema(implementation = MeetingCreateResponseDto.class))
+            ),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @PostMapping("/")
-    public ResponseEntity<MeetingCreateResponseDto> createMeeting(@RequestBody MeetingCreateRequestDto dto) {
+    public ResponseEntity<MeetingCreateResponseDto> createMeeting(
+            @Parameter(
+                    description = "모임 생성 정보",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = MeetingCreateRequestDto.class))
+            )@RequestBody MeetingCreateRequestDto dto
+    ) {
         return ResponseEntity.ok(meetingService.addMeeting(dto));
     }
 
+    @Operation(
+            summary = "모임 정보 조회",
+            description = "링크 코드를 사용하여 모임의 기본 정보를 조회합니다. " +
+                    "모임 제목, 목적 정보를 확인할 수 있습니다. " +
+                    "인증이 필요하지 않는 공개 API입니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "모임 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = MeetingInfoResponseDto.class))
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @GetMapping("/{linkCode}/info")
-    public ResponseEntity<MeetingInfoResponseDto> getMeeting(@PathVariable String linkCode) {
+    public ResponseEntity<MeetingInfoResponseDto> getMeeting(
+            @Parameter(description = "모임 링크 코드")
+            @PathVariable String linkCode
+    ) {
         return ResponseEntity.ok(meetingService.getMeeting(linkCode));
     }
 }

--- a/src/main/java/com/ODG/ODG_back/controller/MidpointController.java
+++ b/src/main/java/com/ODG/ODG_back/controller/MidpointController.java
@@ -1,8 +1,16 @@
 package com.ODG.ODG_back.controller;
 
 import com.ODG.ODG_back.dto.midpoint.response.MidpointResponseDto;
+import com.ODG.ODG_back.security.jwt.JwtTokenProvider;
 import com.ODG.ODG_back.service.MidpointService;
 import com.ODG.ODG_back.strategy.MidpointStrategyType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,14 +18,37 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/meetings/{inviteCode}/midpoint")
 @RequiredArgsConstructor
+@Tag(name = "Midpoint", description = "중간 지점 추천 API")
 public class MidpointController {
 
     private final MidpointService midpointService;
+    private final JwtTokenProvider jwtTokenProvider;
 
+    @Operation(
+            summary = "중간 지점 조회",
+            description = "모임 참가자들의 위치를 기반으로 중간 지점을 조회합니다. " +
+                    "전략은 쿼리 파라미터로 전달됩니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "중간 지점 조회 성공",
+                    content = @Content(schema = @Schema(implementation = MidpointResponseDto.class))
+            ),
+            @ApiResponse(responseCode = "403", description = "인증 실패 (토큰 없음 또는 유효하지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @GetMapping
-    public ResponseEntity<MidpointResponseDto> getRecommendedMidpoints(@PathVariable String inviteCode,
-                                                                            @RequestParam MidpointStrategyType strategyType) {
-        return ResponseEntity.ok(midpointService.getRecommendedMidpoints(inviteCode, strategyType));
+    public ResponseEntity<MidpointResponseDto> getRecommendedMidpoints(
+            @Parameter(description = "모임 링크 코드")
+            @PathVariable String inviteCode,
+            @Parameter(description = "JWT 토큰 (쿠키에서 자동 추출, 아무 값 입력)")
+            @CookieValue("access_token") String jwtToken,
+            @Parameter(description = "전략 타입")
+            @RequestParam MidpointStrategyType strategyType) {
+        String userId = jwtTokenProvider.getUserId(jwtToken);
+        return ResponseEntity.ok(midpointService.getRecommendedMidpoints(inviteCode, strategyType, userId));
     }
 
 }

--- a/src/main/java/com/ODG/ODG_back/controller/ParticipantController.java
+++ b/src/main/java/com/ODG/ODG_back/controller/ParticipantController.java
@@ -7,6 +7,13 @@ import com.ODG.ODG_back.dto.participant.response.ParticipantRegisterResponseDto;
 import com.ODG.ODG_back.security.jwt.JwtCookieUtil;
 import com.ODG.ODG_back.security.jwt.JwtTokenProvider;
 import com.ODG.ODG_back.service.ParticipantService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,14 +27,35 @@ import java.util.UUID;
 @RequestMapping("/meetings/{linkCode}/participants")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "Participant", description = "모임 참가자 관리 API")
 public class ParticipantController {
 
     private final ParticipantService participantService;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Operation(
+            summary = "모임 참가자 등록",
+            description = "모임에 새로운 참가자를 등록하고 JWT 토큰을 쿠키로 설정합니다. " +
+                    "등록 성공 시 access_token 쿠키가 자동으로 브라우저에 저장됩니다. " +
+                    "뿐만 아니라 json으로 access_token을 반환합니다. " +
+                    "인증이 필요한 타 api에선 쿠키에서 access_token을 받으니 유의하십시오. " +
+                    "인증이 필요하지 않는 공개 API입니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "참가자 등록 성공",
+                    content = @Content(schema = @Schema(implementation = ParticipantRegisterResponseDto.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @PostMapping("/register")
     public ResponseEntity<ParticipantRegisterResponseDto> addParticipant(
+            @Parameter(description = "모임 링크 코드")
             @PathVariable String linkCode,
+            @Parameter(description = "참가자 등록 정보")
             @RequestBody ParticipantRegisterRequestDto requestDto,
             HttpServletResponse response
     ){
@@ -45,9 +73,22 @@ public class ParticipantController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @Operation(
+            summary = "모임 참가자 삭제",
+            description = "현재 로그인한 참가자를 모임에서 제거합니다. " +
+                    "쿠키의 JWT 토큰을 사용하여 인증을 수행합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "참가자 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "인증 실패 (토큰 없음 또는 유효하지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임 또는 참가자", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @DeleteMapping("/delete")
     public ResponseEntity<Void> deleteParticipant(
+            @Parameter(description = "모임 링크 코드")
             @PathVariable String linkCode,
+            @Parameter(description = "JWT 토큰 (쿠키에서 자동 추출, 아무 값 입력)")
             @CookieValue("access_token") String jwtToken
     ) {
         String userId = jwtTokenProvider.getUserId(jwtToken);
@@ -55,10 +96,24 @@ public class ParticipantController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(
+            summary = "참가자 정보 수정",
+            description = "현재 로그인한 참가자의 정보를 수정합니다. " +
+                    "쿠키의 JWT 토큰을 사용하여 본인 인증을 수행합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "참가자 정보 수정 성공"),
+            @ApiResponse(responseCode = "403", description = "인증 실패 (토큰 없음 또는 유효하지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임 또는 참가자", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @PutMapping("/update")
     public ResponseEntity<Void> updateParticipant(
+            @Parameter(description = "모임 링크 코드")
             @PathVariable String linkCode,
+            @Parameter(description = "수정할 참가자 정보")
             @RequestBody ParticipantUpdateRequestDto participantUpdateRequestDto,
+            @Parameter(description = "JWT 토큰 (쿠키에서 자동 추출, 아무 값 입력)")
             @CookieValue("access_token") String jwtToken // 쿠키에서 jwt 추출
     ){
         String userId = jwtTokenProvider.getUserId(jwtToken);
@@ -66,9 +121,29 @@ public class ParticipantController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(
+            summary = "모임 참가자 목록 조회",
+            description = "특정 모임의 모든 참가자 목록과 투표 상태를 조회합니다. "
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "참가자 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ParticipantListResponseDto.class))
+            ),
+            @ApiResponse(responseCode = "403", description = "인증 실패 (토큰 없음 또는 유효하지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @GetMapping("/")
-    public ResponseEntity<List<ParticipantListResponseDto>> getParticipants(@PathVariable String linkCode){
-        List<ParticipantListResponseDto> participants = participantService.getParticipantsWithVoteStatus(linkCode);
+    public ResponseEntity<List<ParticipantListResponseDto>> getParticipants(
+            @Parameter(description = "모임 링크 코드")
+            @PathVariable String linkCode,
+            @Parameter(description = "JWT 토큰 (쿠키에서 자동 추출, 아무 값 입력)")
+            @CookieValue("access_token") String jwtToken
+    ){
+        String userId = jwtTokenProvider.getUserId(jwtToken);
+        List<ParticipantListResponseDto> participants = participantService.getParticipantsWithVoteStatus(linkCode, userId);
         return ResponseEntity.ok(participants);
     }
 }

--- a/src/main/java/com/ODG/ODG_back/controller/PlaceController.java
+++ b/src/main/java/com/ODG/ODG_back/controller/PlaceController.java
@@ -1,26 +1,53 @@
 package com.ODG.ODG_back.controller;
 
 import com.ODG.ODG_back.dto.place.response.PlaceResponseDto;
+import com.ODG.ODG_back.security.jwt.JwtTokenProvider;
 import com.ODG.ODG_back.service.PlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/meetings/{inviteCode}")
 @RequiredArgsConstructor
+@Tag(name = "Place", description = "추천 장소 조회 API")
 public class PlaceController {
 
     private final PlaceService placeService;
+    private final JwtTokenProvider jwtTokenProvider;
 
+    @Operation(
+            summary = "추천 장소 조회",
+            description = "모임 중간 지점을 기반으로 추천 장소 목록을 조회합니다. "
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "추천 장소 조회 성공",
+                    content = @Content(schema = @Schema(implementation = PlaceResponseDto.class))
+            ),
+            @ApiResponse(responseCode = "403", description = "인증 실패 (토큰 없음 또는 유효하지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임 또는 중간지점", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @GetMapping("/places")
-    public ResponseEntity<List<PlaceResponseDto>> getPlacesByMidpoint(@PathVariable String inviteCode) {
-        return ResponseEntity.ok(placeService.getPlacesByMidpoint(inviteCode));
+    public ResponseEntity<List<PlaceResponseDto>> getPlacesByMidpoint(
+            @Parameter(description = "모임 초대 코드")
+            @PathVariable String inviteCode,
+            @Parameter(description = "JWT 토큰 (쿠키에서 자동 추출, 아무 값 입력)")
+            @CookieValue("access_token") String jwtToken
+    ) {
+        String userId = jwtTokenProvider.getUserId(jwtToken);
+        return ResponseEntity.ok(placeService.getPlacesByMidpoint(inviteCode, userId));
     }
 
 }

--- a/src/main/java/com/ODG/ODG_back/controller/VoteController.java
+++ b/src/main/java/com/ODG/ODG_back/controller/VoteController.java
@@ -4,6 +4,13 @@ import com.ODG.ODG_back.dto.vote.request.VoteRequestDto;
 import com.ODG.ODG_back.dto.vote.response.VoteResultDto;
 import com.ODG.ODG_back.security.jwt.JwtTokenProvider;
 import com.ODG.ODG_back.service.VoteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,23 +20,58 @@ import java.util.List;
 @RestController
 @RequestMapping("/meetings/{inviteCode}")
 @RequiredArgsConstructor
+@Tag(name = "Vote", description = "투표 관리 API")
 public class VoteController {
 
     private final VoteService voteService;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Operation(
+            summary = "투표 토글",
+            description = "참가자가 특정 장소에 대해 투표를 생성하거나 이미 투표가 된 장소라면 삭제합니다. "
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "투표 토글 성공"),
+            @ApiResponse(responseCode = "403", description = "인증 실패 (토큰 없음 또는 유효하지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임 또는 참가자 또는 장소", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @PostMapping("/vote")
-    public ResponseEntity<Void> vote(@PathVariable String inviteCode,
-                                       @RequestBody VoteRequestDto voteRequestDto,
-                                       @CookieValue("access_token") String jwtToken) {
+    public ResponseEntity<Void> vote(
+            @Parameter(description = "모임 초대 코드")
+            @PathVariable String inviteCode,
+            @Parameter(description = "투표 요청 데이터")
+            @RequestBody VoteRequestDto voteRequestDto,
+            @Parameter(description = "JWT 토큰 (쿠키에서 자동 추출, 아무 값 입력)")
+            @CookieValue("access_token") String jwtToken) {
         String userId = jwtTokenProvider.getUserId(jwtToken);
         voteService.vote(inviteCode, userId, voteRequestDto);
         return ResponseEntity.ok().build();
     }
 
+    @Operation(
+            summary = "투표 결과 조회",
+            description = "특정 모임의 투표 결과를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "투표 결과 조회 성공",
+                    content = @Content(schema = @Schema(implementation = VoteResultDto.class))
+            ),
+            @ApiResponse(responseCode = "403", description = "인증 실패 (토큰 없음 또는 유효하지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @GetMapping("/result")
-    public ResponseEntity<List<VoteResultDto>> getVoteResults(@PathVariable String inviteCode) {
-        List<VoteResultDto> voteResults = voteService.getVoteResults(inviteCode);
+    public ResponseEntity<List<VoteResultDto>> getVoteResults(
+            @Parameter(description = "모임 초대 코드")
+            @PathVariable String inviteCode,
+            @Parameter(description = "JWT 토큰 (쿠키에서 자동 추출, 아무 값 입력)")
+            @CookieValue("access_token") String jwtToken
+            ) {
+        String userId = jwtTokenProvider.getUserId(jwtToken);
+        List<VoteResultDto> voteResults = voteService.getVoteResults(inviteCode, userId);
         return ResponseEntity.ok(voteResults);
     }
 

--- a/src/main/java/com/ODG/ODG_back/service/MidpointService.java
+++ b/src/main/java/com/ODG/ODG_back/service/MidpointService.java
@@ -1,12 +1,16 @@
 package com.ODG.ODG_back.service;
 
+import com.ODG.ODG_back.domain.Meeting;
 import com.ODG.ODG_back.dto.midpoint.response.MidpointResponseDto;
+import com.ODG.ODG_back.exception.ErrorCode;
+import com.ODG.ODG_back.exception.custom.NotFoundException;
+import com.ODG.ODG_back.repository.MeetingRepository;
+import com.ODG.ODG_back.repository.ParticipantRepository;
 import com.ODG.ODG_back.strategy.MidpointStrategy;
 import com.ODG.ODG_back.strategy.MidpointStrategyType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.Map;
 
 @Service
@@ -15,8 +19,14 @@ public class MidpointService {
 
     // 전략 빈 자동 주입
     private final Map<String, MidpointStrategy> strategyMap;
+    private final MeetingRepository meetingRepository;
+    private final ParticipantRepository participantRepository;
 
-    public MidpointResponseDto getRecommendedMidpoints(String inviteCode, MidpointStrategyType strategyType) {
+    public MidpointResponseDto getRecommendedMidpoints(String inviteCode, MidpointStrategyType strategyType, String userId) {
+        Meeting meeting = meetingRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND));
+        participantRepository.findByUserIdAndMeeting(userId, meeting)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND));
         MidpointStrategy strategy = strategyMap.get(strategyType.getBeanName());
 
         return strategy.calculateMidpoints(inviteCode);

--- a/src/main/java/com/ODG/ODG_back/service/ParticipantService.java
+++ b/src/main/java/com/ODG/ODG_back/service/ParticipantService.java
@@ -76,7 +76,12 @@ public class ParticipantService {
 
         participantRepository.delete(participant);
     }
-    public List<ParticipantListResponseDto> getParticipantsWithVoteStatus(String linkCode) {
+    public List<ParticipantListResponseDto> getParticipantsWithVoteStatus(String linkCode, String userId) {
+        Meeting meeting = meetingRepository.findByInviteCode(linkCode)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND));
+        participantRepository.findByUserIdAndMeeting(userId, meeting)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND));
+
         return participantRepository.findParticipantsWithVoteStatus(linkCode);
     }
 }

--- a/src/main/java/com/ODG/ODG_back/service/PlaceService.java
+++ b/src/main/java/com/ODG/ODG_back/service/PlaceService.java
@@ -1,9 +1,6 @@
 package com.ODG.ODG_back.service;
 
-import com.ODG.ODG_back.domain.Meeting;
-import com.ODG.ODG_back.domain.Midpoint;
-import com.ODG.ODG_back.domain.Place;
-import com.ODG.ODG_back.domain.RecommendedMidpoint;
+import com.ODG.ODG_back.domain.*;
 import com.ODG.ODG_back.domain.enums.MeetingType;
 import com.ODG.ODG_back.domain.enums.PlaceCategory;
 import com.ODG.ODG_back.dto.place.response.PlaceResponseDto;
@@ -11,6 +8,7 @@ import com.ODG.ODG_back.exception.ErrorCode;
 import com.ODG.ODG_back.exception.custom.NotFoundException;
 import com.ODG.ODG_back.mapper.PlaceMapper;
 import com.ODG.ODG_back.repository.MeetingRepository;
+import com.ODG.ODG_back.repository.ParticipantRepository;
 import com.ODG.ODG_back.repository.PlaceRepository;
 import com.ODG.ODG_back.repository.RecommendedMidpointRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,13 +23,15 @@ public class PlaceService {
     private final MeetingRepository meetingRepository;
     private final RecommendedMidpointRepository recommendedMidpointRepository;
     private final PlaceRepository placeRepository;
+    private final ParticipantRepository participantRepository;
 
     private final PlaceMapper placeMapper;
 
-    public List<PlaceResponseDto> getPlacesByMidpoint(String inviteCode) {
+    public List<PlaceResponseDto> getPlacesByMidpoint(String inviteCode, String userId) {
         Meeting meeting = meetingRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND));
-
+        participantRepository.findByUserIdAndMeeting(userId, meeting)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND));
         RecommendedMidpoint recommendedMidpoint = recommendedMidpointRepository.findByMeeting(meeting)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.RECOMMENDED_MIDPOINT_NOT_FOUND));
         Midpoint midpoint = recommendedMidpoint.getMidpoint();

--- a/src/main/java/com/ODG/ODG_back/service/VoteService.java
+++ b/src/main/java/com/ODG/ODG_back/service/VoteService.java
@@ -34,7 +34,7 @@ public class VoteService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND));
         Place place = placeRepository.findById(voteRequestDto.getPlaceId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PLACE_NOT_FOUND));
-        Participant participant = participantRepository.findByUserId(userId)
+        Participant participant = participantRepository.findByUserIdAndMeeting(userId, meeting)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND));
 
         Optional<Vote> existingVote = voteRepository.findByMeetingAndPlaceAndParticipant(meeting, place, participant);
@@ -47,10 +47,11 @@ public class VoteService {
         }
     }
 
-    public List<VoteResultDto> getVoteResults(String inviteCode) {
+    public List<VoteResultDto> getVoteResults(String inviteCode, String userId) {
         Meeting meeting = meetingRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND));
-
+        participantRepository.findByUserIdAndMeeting(userId, meeting)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND));
         return voteRepository.findVoteCountsByMeeting(meeting);
     }
 }


### PR DESCRIPTION
### Swagger API 명세를 더 구체적으로 작성했습니다. 
- 각 API에 무슨 기능인지 설명을 적었고, 어떤 에러 코드가 어떤 의미인지 적어두었습니다. 
- 또, 기존의 jwt access token을 필요로 하는 API에 대한 구분이 명확하지 않았는데, jwt 인증을 하는 경우에는 swagger 상으로 쿠키에 `access_token`을 넣어야 함을 명시했습니다.  
- 그러나 swagger test를 사용할 때, 쿠키에 access_token이 들어가 있다면 아무 값이나 `access_token`에 넣어도 됩니다. (swagger test 상으로는 `/register`를 하면 자동으로 쿠키에 access_token이 들어가서 별도의 조작은 필요없습니다.)

### 참가자가 해당 모임에 참여하고 있는지 항상 확인합니다. 
- jwt 인증을 하지 않는 `/meetings/`, `/meetings/{linkCode}/info`, `/meetings/{linkCode}/participants/register`를 제외한 API들을 사용할 때 `access_token`으로 사용자를 식별하고 이 사용자가 `linkCode`에 해당하는 모임에 참가하는지 확인하도록 했습니다. 
- 기존에는 jwt 인증만 되면 다른 모임의 정보를 얻을 수 있었습니다. 
- 겸사겸사 swagger API 명세도 명확해졌습니다. 