### PR TITLE
Feature:Midpoint 리팩토링

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,6 +40,8 @@ jobs:
           host: ${{ secrets.AWS_EC2_HOST }}
           username: ${{ secrets.AWS_EC2_USERNAME }}
           key: ${{ secrets.AWS_EC2_SSH_KEY }}
+          timeout: 1800s
+          command_timeout: 1800s
           script: |
             export DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
             export DB_URL="${{ secrets.DB_URL }}"

--- a/src/main/java/com/ODG/ODG_back/controller/ParticipantController.java
+++ b/src/main/java/com/ODG/ODG_back/controller/ParticipantController.java
@@ -4,13 +4,17 @@ import com.ODG.ODG_back.dto.participant.request.ParticipantRegisterRequestDto;
 import com.ODG.ODG_back.dto.participant.request.ParticipantUpdateRequestDto;
 import com.ODG.ODG_back.dto.participant.response.ParticipantListResponseDto;
 import com.ODG.ODG_back.dto.participant.response.ParticipantRegisterResponseDto;
+import com.ODG.ODG_back.exception.ErrorCode;
+import com.ODG.ODG_back.exception.custom.UnauthorizedException;
 import com.ODG.ODG_back.security.jwt.JwtCookieUtil;
+import com.ODG.ODG_back.security.jwt.JwtTokenFilter;
 import com.ODG.ODG_back.security.jwt.JwtTokenProvider;
 import com.ODG.ODG_back.service.ParticipantService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,18 +27,15 @@ import java.util.UUID;
 public class ParticipantController {
 
     private final ParticipantService participantService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/register")
     public ResponseEntity<ParticipantRegisterResponseDto> addParticipant(
             @PathVariable String linkCode,
-            @RequestBody ParticipantRegisterRequestDto requestDto,
-            HttpServletResponse response
+            @RequestBody ParticipantRegisterRequestDto requestDto
     ) {
         String userId = UUID.randomUUID().toString();
         ParticipantRegisterResponseDto responseDto = participantService.addParticipant(linkCode,
                 requestDto, userId);
-        JwtCookieUtil.addTokenToCookie(response, responseDto.getAccessToken());
 
         log.info("resp pid={}, nick={}, tokenNull={}, ttl={}",
                 responseDto.getParticipantId(),
@@ -49,9 +50,12 @@ public class ParticipantController {
     @DeleteMapping("/delete")
     public ResponseEntity<Void> deleteParticipant(
             @PathVariable String linkCode,
-            @CookieValue("access_token") String jwtToken
+            Authentication auth
     ) {
-        String userId = jwtTokenProvider.getUserId(jwtToken);
+        if (auth == null || auth.getPrincipal() == null) {
+            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
+        }
+        String userId = (String) auth.getPrincipal();
         participantService.deleteParticipant(linkCode, userId);
         return ResponseEntity.ok().build();
     }
@@ -60,9 +64,12 @@ public class ParticipantController {
     public ResponseEntity<Void> updateParticipant(
             @PathVariable String linkCode,
             @RequestBody ParticipantUpdateRequestDto participantUpdateRequestDto,
-            @CookieValue("access_token") String jwtToken // 쿠키에서 jwt 추출
+            Authentication auth
     ) {
-        String userId = jwtTokenProvider.getUserId(jwtToken);
+        if (auth == null || auth.getPrincipal() == null) {
+            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
+        }
+        String userId = (String) auth.getPrincipal();
         participantService.modifyParticipant(linkCode, userId, participantUpdateRequestDto);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/ODG/ODG_back/controller/PlaceController.java
+++ b/src/main/java/com/ODG/ODG_back/controller/PlaceController.java
@@ -2,12 +2,15 @@ package com.ODG.ODG_back.controller;
 
 import com.ODG.ODG_back.dto.place.response.GroupedPlacesResponse;
 import com.ODG.ODG_back.dto.place.response.PlaceResponseDto;
+import com.ODG.ODG_back.exception.ErrorCode;
+import com.ODG.ODG_back.exception.custom.UnauthorizedException;
 import com.ODG.ODG_back.security.jwt.JwtTokenProvider;
 import com.ODG.ODG_back.service.ParticipantService;
 import com.ODG.ODG_back.service.PlaceService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,7 +26,6 @@ import java.util.List;
 public class PlaceController {
 
     private final PlaceService placeService;
-    private final JwtTokenProvider jwtTokenProvider;
     private final ParticipantService participantService;
 
     @GetMapping("/places")
@@ -33,10 +35,12 @@ public class PlaceController {
             @RequestParam(defaultValue = "15") int size,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "false") boolean append,
-            HttpServletRequest request
+            Authentication auth
     ) {
-        String token = jwtTokenProvider.resolveToken(request);
-        String userId = jwtTokenProvider.getUserId(token);
+        if (auth == null || auth.getPrincipal() == null) {
+            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
+        }
+        String userId = (String) auth.getPrincipal();
         Long participantId = participantService.getParticipantId(userId);
         return ResponseEntity.ok(
                 placeService.getPlacesByMidpointGrouped(inviteCode, radius, size, page, append, participantId));

--- a/src/main/java/com/ODG/ODG_back/controller/VoteController.java
+++ b/src/main/java/com/ODG/ODG_back/controller/VoteController.java
@@ -2,14 +2,14 @@ package com.ODG.ODG_back.controller;
 
 import com.ODG.ODG_back.dto.place.response.PlaceResponseDto;
 import com.ODG.ODG_back.dto.vote.request.VoteRequestDto;
-import com.ODG.ODG_back.dto.vote.response.VoteResultDto;
+import com.ODG.ODG_back.exception.ErrorCode;
+import com.ODG.ODG_back.exception.custom.UnauthorizedException;
 import com.ODG.ODG_back.security.jwt.JwtTokenProvider;
 import com.ODG.ODG_back.service.VoteService;
 import com.ODG.ODG_back.service.VoteService.VoteInstantResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,13 +20,16 @@ import java.util.List;
 public class VoteController {
 
     private final VoteService voteService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/vote")
-    public ResponseEntity<VoteInstantResponse> vote(@PathVariable String inviteCode,
-            @RequestBody VoteRequestDto voteRequestDto, HttpServletRequest request) {
-        String token = jwtTokenProvider.resolveToken(request);
-        String userId = jwtTokenProvider.getUserId(token);
+    public ResponseEntity<VoteInstantResponse> vote(
+            @PathVariable String inviteCode,
+            @RequestBody VoteRequestDto voteRequestDto,
+            Authentication auth) {
+        if (auth == null || auth.getPrincipal() == null) {
+            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
+        }
+        String userId = (String) auth.getPrincipal();
         return ResponseEntity.ok(voteService.vote(inviteCode, userId, voteRequestDto));
     }
 

--- a/src/main/java/com/ODG/ODG_back/domain/enums/TransportType.java
+++ b/src/main/java/com/ODG/ODG_back/domain/enums/TransportType.java
@@ -1,6 +1,13 @@
 package com.ODG.ODG_back.domain.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public enum TransportType {
     PUBLIC,
-    CAR
+    CAR;
+
+    @JsonCreator
+    public static TransportType from(String v) {
+        return TransportType.valueOf(v.trim().toUpperCase());
+    }
 }

--- a/src/main/java/com/ODG/ODG_back/security/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/ODG/ODG_back/security/jwt/JwtTokenFilter.java
@@ -27,10 +27,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
-        String token = jwtTokenProvider.resolveToken(request);
-        if (token == null) {
-            token = JwtCookieUtil.extractTokenFromCookie(request);
-        }
+        String token = resolveToken(request);
 
         if (token != null) {
             try {
@@ -44,10 +41,24 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(auth);
             } catch (UnauthorizedException e) {
                 SecurityContextHolder.clearContext();
-                throw e;
             }
         }
         filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header == null)
+            return null;
+
+        String value = header.trim();
+        if (value.regionMatches(true, 0, "Bearer", 0, 6)) {
+            int sp = value.indexOf(' ');
+            if (sp > 0 && sp + 1 < value.length()) {
+                return value.substring(sp + 1).trim();
+            }
+        }
+        return null;
     }
 
 }

--- a/src/main/java/com/ODG/ODG_back/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ODG/ODG_back/security/jwt/JwtTokenProvider.java
@@ -60,12 +60,4 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
-    public String resolveToken(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        if (bearer != null && bearer.startsWith("Bearer")) {
-            return bearer.substring(7);
-        }
-        return null;
-    }
-
 }

--- a/src/main/java/com/ODG/ODG_back/service/MidpointService.java
+++ b/src/main/java/com/ODG/ODG_back/service/MidpointService.java
@@ -1,25 +1,63 @@
 package com.ODG.ODG_back.service;
 
+import com.ODG.ODG_back.domain.Meeting;
+import com.ODG.ODG_back.domain.RecommendedMidpoint;
 import com.ODG.ODG_back.dto.midpoint.response.MidpointResponseDto;
+import com.ODG.ODG_back.exception.ErrorCode;
+import com.ODG.ODG_back.exception.custom.NotFoundException;
+import com.ODG.ODG_back.mapper.MidpointMapper;
+import com.ODG.ODG_back.repository.MeetingRepository;
+import com.ODG.ODG_back.repository.RecommendedMidpointRepository;
 import com.ODG.ODG_back.strategy.MidpointStrategy;
 import com.ODG.ODG_back.strategy.MidpointStrategyType;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MidpointService {
 
     // 전략 빈 자동 주입
     private final Map<String, MidpointStrategy> strategyMap;
+    private final RecommendedMidpointRepository recommendedMidpointRepository;
+    private final MeetingRepository meetingRepository;
+    private final MidpointMapper midpointMapper;
 
     public MidpointResponseDto getRecommendedMidpoints(String inviteCode,
             MidpointStrategyType strategyType) {
         MidpointStrategy strategy = strategyMap.get(strategyType.getBeanName());
+        Meeting meeting = meetingRepository.findByInviteCode(inviteCode).orElseThrow(
+                () -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND)
+        );
 
-        return strategy.calculateMidpoints(inviteCode);
+        MidpointStrategy.MidpointScoreWithMeta best = strategy.calculateMidpoints(meeting);
+        saveRecommendedMidpoint(best, meeting);
+
+        return midpointMapper.toDtoSelfOnly(
+                best.midpointScore().midpoint(),
+                best.midpointScore().avg(),
+                best.midpointScore().totalDeviation(),
+                best.participantId(),
+                best.selfTimeSeconds(),
+                best.participantCount()
+        );
+    }
+
+    private void saveRecommendedMidpoint(MidpointStrategy.MidpointScoreWithMeta best, Meeting meeting) {
+        log.info("Saving recommended midpoint: {}, average time: {}", best.midpointScore().midpoint().getName(),
+                best.midpointScore().avg());
+        RecommendedMidpoint recommended = new RecommendedMidpoint(
+                null,
+                best.midpointScore().avg(),
+                1,
+                java.time.LocalDateTime.now(),
+                meeting,
+                best.midpointScore().midpoint()
+        );
+        recommendedMidpointRepository.save(recommended);
     }
 }

--- a/src/main/java/com/ODG/ODG_back/strategy/MidpointStrategy.java
+++ b/src/main/java/com/ODG/ODG_back/strategy/MidpointStrategy.java
@@ -1,5 +1,6 @@
 package com.ODG.ODG_back.strategy;
 
+import com.ODG.ODG_back.domain.Meeting;
 import com.ODG.ODG_back.domain.Midpoint;
 import com.ODG.ODG_back.domain.Participant;
 import com.ODG.ODG_back.dto.midpoint.response.MidpointResponseDto;
@@ -14,7 +15,7 @@ import java.util.function.ToDoubleFunction;
 
 public interface MidpointStrategy {
 
-    MidpointResponseDto calculateMidpoints(String inviteCode);
+    MidpointScoreWithMeta calculateMidpoints(Meeting meeting);
 
     default List<Midpoint> hubNearCenter(List<Participant> ps, List<Midpoint> stations) {
         if (stations.size() <= 25) {
@@ -103,4 +104,6 @@ public interface MidpointStrategy {
     record TimeMatrix(int[][] matrix, List<Participant> rowOrder) {};
     record MidpointScore(Midpoint midpoint, double avg, double totalDeviation,
                          int[] times) {};
+
+    record MidpointScoreWithMeta(MidpointScore midpointScore, Long participantId, int selfTimeSeconds, int participantCount) {}
 }

--- a/src/main/java/com/ODG/ODG_back/strategy/MidpointStrategy.java
+++ b/src/main/java/com/ODG/ODG_back/strategy/MidpointStrategy.java
@@ -1,8 +1,106 @@
 package com.ODG.ODG_back.strategy;
 
+import com.ODG.ODG_back.domain.Midpoint;
+import com.ODG.ODG_back.domain.Participant;
 import com.ODG.ODG_back.dto.midpoint.response.MidpointResponseDto;
+import com.ODG.ODG_back.exception.ErrorCode;
+import com.ODG.ODG_back.exception.custom.NotFoundException;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.ToDoubleFunction;
 
 public interface MidpointStrategy {
 
     MidpointResponseDto calculateMidpoints(String inviteCode);
+
+    default List<Midpoint> hubNearCenter(List<Participant> ps, List<Midpoint> stations) {
+        if (stations.size() <= 25) {
+            return stations;
+        }
+
+        double centerLat = ps.stream()
+                .map(Participant::getLatitude)
+                .mapToDouble(BigDecimal::doubleValue)
+                .average()
+                .orElse(0.0);
+        double centerLon = ps.stream()
+                .map(Participant::getLongitude)
+                .mapToDouble(BigDecimal::doubleValue)
+                .average()
+                .orElse(0.0);
+
+        ToDoubleFunction<Midpoint> hub = s -> {
+            try {
+                Double v = s.getHubScore();
+                return v == null ? 0.0 : v;
+            } catch (Exception e) {
+                return 0.0;
+            }
+        };
+
+        return stations.stream()
+                .sorted(Comparator.comparingDouble((Midpoint s) ->
+                                -hub.applyAsDouble(s))
+                        .thenComparingDouble(
+                                s -> haversine(centerLat, centerLon, s.getLatitude().doubleValue(),
+                                        s.getLongitude().doubleValue()))
+                )
+                .limit(25)
+                .toList();
+    }
+
+    default double haversine(double lat1, double lon1, double lat2, double lon2) {
+        final double R = 6371.0088; // 지구 반지름 (km)
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
+                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c; // 거리 (km)
+    }
+
+    default MidpointScore scoreMidpoints(int[][] timeMatrix, List<Midpoint> midpoints,
+                                         int numParticipants, List<Participant> rowOrder) {
+        List<MidpointScore> scored = new ArrayList<>();
+
+        for (int j = 0; j < midpoints.size(); j++) {
+            int sum = 0;
+            int[] times = new int[numParticipants];
+            for (int i = 0; i < numParticipants; i++) {
+                times[i] = timeMatrix[i][j];
+                sum += times[i];
+            }
+            double avg = sum / (double) numParticipants;
+
+            double totalDeviation = 0;
+            for (int i = 0; i < numParticipants; i++) {
+                totalDeviation += Math.abs(times[i] - avg);
+            }
+
+            scored.add(new MidpointScore(midpoints.get(j), avg, totalDeviation, times));
+        }
+
+        return scored.stream()
+                .sorted(Comparator.comparingDouble(MidpointScore::avg)
+                        .thenComparingDouble(MidpointScore::totalDeviation))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException());
+    }
+
+    default int findRowIndex(List<Participant> rowOrder, Long pid) {
+        for (int i = 0; i < rowOrder.size(); i++) {
+            if (rowOrder.get(i).getId().equals(pid)) {
+                return i;
+            }
+        }
+        throw new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND);
+    }
+
+    record TimeMatrix(int[][] matrix, List<Participant> rowOrder) {};
+    record MidpointScore(Midpoint midpoint, double avg, double totalDeviation,
+                         int[] times) {};
 }

--- a/src/main/java/com/ODG/ODG_back/strategy/SubwayMidpointStrategy.java
+++ b/src/main/java/com/ODG/ODG_back/strategy/SubwayMidpointStrategy.java
@@ -1,6 +1,7 @@
 package com.ODG.ODG_back.strategy;
 
 import com.ODG.ODG_back.domain.*;
+import com.ODG.ODG_back.domain.enums.TransportType;
 import com.ODG.ODG_back.dto.external.OverpassStationInfoDTO;
 import com.ODG.ODG_back.dto.midpoint.response.MidpointResponseDto;
 import com.ODG.ODG_back.exception.ErrorCode;
@@ -13,27 +14,34 @@ import com.ODG.ODG_back.repository.MeetingRepository;
 import com.ODG.ODG_back.repository.MidpointRepository;
 import com.ODG.ODG_back.repository.RecommendedMidpointRepository;
 import com.ODG.ODG_back.repository.SubwayDurationTimeRepository;
+import com.ODG.ODG_back.service.AuthService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.groupingBy;
 
 @Component("subwayStrategy")
 @RequiredArgsConstructor
+@Slf4j
 public class SubwayMidpointStrategy implements MidpointStrategy {
-
-    private final int MAX_DISTANCE = 2000; // 최대 검색 거리 (미터 단위)
     private final MeetingRepository meetingRepository;
     private final RecommendedMidpointRepository recommendedMidpointRepository;
     private final MidpointRepository midpointRepository;
     private final MidpointMapper midpointMapper;
     private final SubwayDurationTimeRepository timeRepository; // 지하철역간 이동 시간 저장소
+    private final GoogleMatrixApiClient matrixApiClient; // 소요 시간 API 요청
+    private final AuthService authService;
+
 
     @Override
     public MidpointResponseDto calculateMidpoints(String inviteCode) {
+        log.info("Calculating midpoints for inviteCode: {}", inviteCode);
 
         Meeting meeting = meetingRepository.findByInviteCode(inviteCode).orElseThrow(
                 () -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND)
@@ -42,74 +50,123 @@ public class SubwayMidpointStrategy implements MidpointStrategy {
         List<Participant> participants = meeting.getParticipants();
         // 목적지 = 모든 지하철역
         List<Midpoint> allMidpoints = midpointRepository.findAll();
+        log.info("Number of participants: {}, number of midpoints: {}", participants.size(),
+                allMidpoints.size());
 
-        // 각 participant별로 allMidpoints에서 가장 가까운 지하철역을 찾아 리스트에 추가
+        List<Midpoint> candidates = hubNearCenter(participants, allMidpoints);
 
-        List<Midpoint> nearestMidpoints = new ArrayList<>();
-        for (Participant participant : participants) {
-            Midpoint nearest = allMidpoints.stream()
-                    .min(Comparator.comparing(midpoint ->
-                            participant.getLatitude().subtract(midpoint.getLatitude()).abs()
-                                    .add(participant.getLongitude()
-                                            .subtract(midpoint.getLongitude()).abs())
-                    ))
-                    .orElseThrow(RuntimeException::new);
-            nearestMidpoints.add(nearest);
-        }
+        TimeMatrix tm = buildTimeMatrix(participants, candidates);
+        int[][] timeMatrix = tm.matrix();
+        List<Participant> rowOrder = tm.rowOrder();
+        log.info("Time matrix dimensions: {} participants × {} midpoints", timeMatrix.length,
+                timeMatrix[0].length);
 
-        List<MidpointScore> midpointScores = calculateMidpointScores(nearestMidpoints, allMidpoints,
-                participants.size());
+        MidpointScore best = scoreMidpoints(timeMatrix, candidates, participants.size(), rowOrder);
+        log.info("Best midpoint: {}, average time: {}", best.midpoint().getName(), best.avg());
 
-        MidpointScore best = midpointScores.stream()
-                .min(Comparator.comparingDouble(MidpointScore::totalDeviation))
-                .orElseThrow(RuntimeException::new);
+        Long currentPid = authService.getCurrentParticipantId(meeting);
+        int rowIndex = findRowIndex(rowOrder, currentPid);
+        int selfTime = best.times()[rowIndex];
 
         saveRecommendedMidpoint(best, meeting);
-        return midpointMapper.toDto(best.midpoint());
+        return midpointMapper.toDtoSelfOnly(
+                best.midpoint(),
+                best.avg(),
+                best.totalDeviation(),
+                currentPid,
+                selfTime,
+                participants.size()
+        );
     }
 
-    // 각 참가자별 가장 가까운 역(nearbyStationsForEachParticipant)과 모든 Midpoint의 역 정보를 기반으로
-    // 각 Midpoint까지의 소요 시간 합(midPointScore)을 계산하여 반환하는 메서드
-    public List<MidpointScore> calculateMidpointScores(
-            List<Midpoint> nearbyStationsForEachParticipant,
-            List<Midpoint> allMidpoints,
-            int numberOfParticipants) {
+    Midpoint getNearbySubwayStationMidpoint(Participant participant) {
+        List<Midpoint> allMidpoints = midpointRepository.findAll();
+        BigDecimal minDistance = null;
+        Midpoint nearest = null;
 
-        List<MidpointScore> scores = new ArrayList<>();
+        BigDecimal lat = participant.getLatitude();
+        BigDecimal lon = participant.getLongitude();
 
         for (Midpoint midpoint : allMidpoints) {
-            var score = calculateMidpointScore(nearbyStationsForEachParticipant,
-                    numberOfParticipants, midpoint);
+            BigDecimal stationLat = midpoint.getLatitude();
+            BigDecimal stationLng = midpoint.getLongitude();
 
-            if (score != null) {
-                scores.add(score);
+            BigDecimal LatDiff = lat.subtract(stationLat);
+            BigDecimal LngDiff = lon.subtract(stationLng);
+
+            BigDecimal distancePow = BigDecimal.valueOf(Math.pow(LatDiff.doubleValue(), 2) + Math.pow(LngDiff.doubleValue(), 2));
+
+            if (nearest == null || distancePow.compareTo(minDistance) < 0) {
+                minDistance = distancePow;
+                nearest = midpoint;
             }
         }
 
-        return scores;
+        if (nearest == null) {
+            throw new NotFoundException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        return nearest;
     }
 
-    public MidpointScore calculateMidpointScore(List<Midpoint> nearbyStationsForEachParticipant,
-            int numberOfParticipants, Midpoint midpoint) {
-        int totalDuration = 0;
+    private TimeMatrix buildTimeMatrix(List<Participant> participants, List<Midpoint> candidates) {
+        int[][] timeMatrix = new int[participants.size()][candidates.size()];
 
-        try {
+        // transportType 기준으로 그룹화하되, 키 순서를 안정화(TreeMap)하고, 각 그룹 내부는 id 기준으로 정렬
+        Map<TransportType, List<Participant>> grouped = participants.stream()
+                .collect(groupingBy(Participant::getTransportType, TreeMap::new,
+                        Collectors.toList()));
+        List<Participant> rowOrder = new ArrayList<>(participants.size());
 
-            for (Midpoint startStation : nearbyStationsForEachParticipant) {
-                // 시작역과 목적지역 이름이 모두 존재해야 함
+        int rowIndex = 0;
 
-                // SubwayDurationTimeRepository에서 소요 시간 조회
-                SubwayDurationTime durationOpt = getDurationInfo(startStation, midpoint);
-                totalDuration += durationOpt.getShortestDurationTime();
+        for (var entry : grouped.entrySet()) {
+            int[][] groupMatrix;
 
-                return new MidpointScore(midpoint, (double) totalDuration / numberOfParticipants,
-                        totalDuration);
+            List<Participant> group = entry.getValue().stream()
+                    .sorted(Comparator.comparing(Participant::getId))
+                    .toList();
+
+            List<String> origins = group.stream()
+                    .map(p -> p.getLatitude() + "," + p.getLongitude())
+                    .toList();
+
+            if(entry.getKey() == TransportType.CAR) {
+                List<String> destinations = candidates.stream()
+                        .map(m -> m.getLatitude() + "," + m.getLongitude())
+                        .toList();
+
+                groupMatrix = matrixApiClient.getTimeMatrix(origins, destinations,
+                        entry.getKey());
             }
-        } catch (NotFoundException e) {
-            // 해당 midpoint에 대한 정보가 없으면 유효하지 않은 것으로 간주
-        }
+            else{
+                groupMatrix = new int[group.size()][candidates.size()];
 
-        return null;
+                for(int i = 0 ; i < participants.size() ; i++){
+                    for(int j = 0 ; j < candidates.size() ; j++){
+                        SubwayDurationTime durationTime = getDurationInfo(
+                                getNearbySubwayStationMidpoint(participants.get(i)),
+                                candidates.get(j)
+                        );
+
+                        groupMatrix[i][j] = durationTime.getShortestDurationTime() + getWalkTimeToStation(participants.get(i), getNearbySubwayStationMidpoint(participants.get(i)));
+                    }
+                }
+            }
+
+            for (int i = 0; i < group.size(); i++) {
+                timeMatrix[rowIndex] = groupMatrix[i];
+                rowOrder.add(group.get(i)); // 행과 참가자 매핑 기록
+                rowIndex++;
+            }
+        }
+        return new TimeMatrix(timeMatrix, rowOrder);
+    }
+
+    private int getWalkTimeToStation(Participant p, Midpoint m) {
+        double distance = haversine(p.getLatitude().doubleValue(), p.getLongitude().doubleValue(),
+                m.getLatitude().doubleValue(), m.getLongitude().doubleValue());
+        return (int) ((distance * 1000) / 80); // 도보 속도 80m/min 가정
     }
 
     public SubwayDurationTime getDurationInfo(
@@ -141,14 +198,10 @@ public class SubwayMidpointStrategy implements MidpointStrategy {
                 null,
                 best.avg(),
                 1,
-                java.time.LocalDateTime.now(),
+                LocalDateTime.now(),
                 meeting,
                 best.midpoint()
         );
         recommendedMidpointRepository.save(recommended);
-    }
-
-    public record MidpointScore(Midpoint midpoint, double avg, double totalDeviation) {
-
     }
 }

--- a/src/main/java/com/ODG/ODG_back/strategy/SubwayMidpointStrategy.java
+++ b/src/main/java/com/ODG/ODG_back/strategy/SubwayMidpointStrategy.java
@@ -30,8 +30,6 @@ import static java.util.stream.Collectors.groupingBy;
 @RequiredArgsConstructor
 @Slf4j
 public class SubwayMidpointStrategy implements MidpointStrategy {
-    private final MeetingRepository meetingRepository;
-    private final RecommendedMidpointRepository recommendedMidpointRepository;
     private final MidpointRepository midpointRepository;
     private final MidpointMapper midpointMapper;
     private final SubwayDurationTimeRepository timeRepository; // 지하철역간 이동 시간 저장소
@@ -40,12 +38,9 @@ public class SubwayMidpointStrategy implements MidpointStrategy {
 
 
     @Override
-    public MidpointResponseDto calculateMidpoints(String inviteCode) {
-        log.info("Calculating midpoints for inviteCode: {}", inviteCode);
+    public MidpointScoreWithMeta calculateMidpoints(Meeting meeting) {
+        log.info("Calculating midpoints for inviteCode: {}", meeting.getInviteCode());
 
-        Meeting meeting = meetingRepository.findByInviteCode(inviteCode).orElseThrow(
-                () -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND)
-        );
         // 출발지 = 참가자 위치
         List<Participant> participants = meeting.getParticipants();
         // 목적지 = 모든 지하철역
@@ -68,11 +63,8 @@ public class SubwayMidpointStrategy implements MidpointStrategy {
         int rowIndex = findRowIndex(rowOrder, currentPid);
         int selfTime = best.times()[rowIndex];
 
-        saveRecommendedMidpoint(best, meeting);
-        return midpointMapper.toDtoSelfOnly(
-                best.midpoint(),
-                best.avg(),
-                best.totalDeviation(),
+        return new MidpointScoreWithMeta(
+                best,
                 currentPid,
                 selfTime,
                 participants.size()
@@ -149,7 +141,7 @@ public class SubwayMidpointStrategy implements MidpointStrategy {
                                 candidates.get(j)
                         );
 
-                        groupMatrix[i][j] = durationTime.getShortestDurationTime() + getWalkTimeToStation(participants.get(i), getNearbySubwayStationMidpoint(participants.get(i)));
+                        groupMatrix[i][j] = durationTime.getShortestDurationTime() * 60 + getWalkTimeToStation(participants.get(i), getNearbySubwayStationMidpoint(participants.get(i)));
                     }
                 }
             }
@@ -166,7 +158,7 @@ public class SubwayMidpointStrategy implements MidpointStrategy {
     private int getWalkTimeToStation(Participant p, Midpoint m) {
         double distance = haversine(p.getLatitude().doubleValue(), p.getLongitude().doubleValue(),
                 m.getLatitude().doubleValue(), m.getLongitude().doubleValue());
-        return (int) ((distance * 1000) / 80); // 도보 속도 80m/min 가정
+        return (int) ((distance * 1000) / 80) * 60; // 도보 속도 80m/min 가정
     }
 
     public SubwayDurationTime getDurationInfo(
@@ -191,17 +183,5 @@ public class SubwayMidpointStrategy implements MidpointStrategy {
         }
 
         return durationTime.get();
-    }
-
-    private void saveRecommendedMidpoint(MidpointScore best, Meeting meeting) {
-        RecommendedMidpoint recommended = new RecommendedMidpoint(
-                null,
-                best.avg(),
-                1,
-                LocalDateTime.now(),
-                meeting,
-                best.midpoint()
-        );
-        recommendedMidpointRepository.save(recommended);
     }
 }

--- a/src/main/java/com/ODG/ODG_back/strategy/TimeMatrixMidpointStrategy.java
+++ b/src/main/java/com/ODG/ODG_back/strategy/TimeMatrixMidpointStrategy.java
@@ -34,7 +34,6 @@ import static java.util.stream.Collectors.groupingBy;
 public class TimeMatrixMidpointStrategy implements MidpointStrategy {
 
     private final MeetingRepository meetingRepository;
-    private final RecommendedMidpointRepository recommendedMidpointRepository;
     private final GoogleMatrixApiClient matrixApiClient; // 소요 시간 API 요청
     private final MidpointRepository midpointRepository;
     private final MidpointMapper midpointMapper;
@@ -42,12 +41,9 @@ public class TimeMatrixMidpointStrategy implements MidpointStrategy {
     private final AuthService authService;
 
     @Override
-    public MidpointResponseDto calculateMidpoints(String inviteCode) {
-        log.info("Calculating midpoints for inviteCode: {}", inviteCode);
+    public MidpointScoreWithMeta calculateMidpoints(Meeting meeting) {
+        log.info("Calculating midpoints for inviteCode: {}", meeting.getInviteCode());
 
-        Meeting meeting = meetingRepository.findByInviteCode(inviteCode).orElseThrow(
-                () -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND)
-        );
         // 출발지 = 참가자 위치
         List<Participant> participants = meeting.getParticipants();
         // 목적지 = 모든 지하철역
@@ -70,18 +66,13 @@ public class TimeMatrixMidpointStrategy implements MidpointStrategy {
         int rowIndex = findRowIndex(rowOrder, currentPid);
         int selfTime = best.times()[rowIndex];
 
-        saveRecommendedMidpoint(best, meeting);
-        return midpointMapper.toDtoSelfOnly(
-                best.midpoint(),
-                best.avg(),
-                best.totalDeviation(),
+        return new MidpointScoreWithMeta(
+                best,
                 currentPid,
                 selfTime,
                 participants.size()
         );
     }
-
-
 
     private TimeMatrix buildTimeMatrix(List<Participant> participants, List<Midpoint> candidates) {
 
@@ -119,17 +110,4 @@ public class TimeMatrixMidpointStrategy implements MidpointStrategy {
         return new TimeMatrix(timeMatrix, rowOrder);
     }
 
-    private void saveRecommendedMidpoint(MidpointScore best, Meeting meeting) {
-        log.info("Saving recommended midpoint: {}, average time: {}", best.midpoint().getName(),
-                best.avg());
-        RecommendedMidpoint recommended = new RecommendedMidpoint(
-                null,
-                best.avg(),
-                1,
-                java.time.LocalDateTime.now(),
-                meeting,
-                best.midpoint()
-        );
-        recommendedMidpointRepository.save(recommended);
-    }
 }

--- a/src/main/java/com/ODG/ODG_back/strategy/TimeMatrixMidpointStrategy.java
+++ b/src/main/java/com/ODG/ODG_back/strategy/TimeMatrixMidpointStrategy.java
@@ -81,45 +81,7 @@ public class TimeMatrixMidpointStrategy implements MidpointStrategy {
         );
     }
 
-    private List<Midpoint> hubNearCenter(List<Participant> ps, List<Midpoint> stations) {
-        if (stations.size() <= 25) {
-            return stations;
-        }
 
-        double centerLat = ps.stream()
-                .map(Participant::getLatitude)
-                .mapToDouble(BigDecimal::doubleValue)
-                .average()
-                .orElse(0.0);
-        double centerLon = ps.stream()
-                .map(Participant::getLongitude)
-                .mapToDouble(BigDecimal::doubleValue)
-                .average()
-                .orElse(0.0);
-
-        ToDoubleFunction<Midpoint> hub = s -> {
-            try {
-                Double v = s.getHubScore();
-                return v == null ? 0.0 : v;
-            } catch (Exception e) {
-                return 0.0;
-            }
-        };
-
-        return stations.stream()
-                .sorted(Comparator.comparingDouble((Midpoint s) ->
-                                -hub.applyAsDouble(s))
-                        .thenComparingDouble(
-                                s -> haversine(centerLat, centerLon, s.getLatitude().doubleValue(),
-                                        s.getLongitude().doubleValue()))
-                )
-                .limit(25)
-                .toList();
-    }
-
-    private record TimeMatrix(int[][] matrix, List<Participant> rowOrder) {
-
-    }
 
     private TimeMatrix buildTimeMatrix(List<Participant> participants, List<Midpoint> candidates) {
 
@@ -157,54 +119,6 @@ public class TimeMatrixMidpointStrategy implements MidpointStrategy {
         return new TimeMatrix(timeMatrix, rowOrder);
     }
 
-    private MidpointScore scoreMidpoints(int[][] timeMatrix, List<Midpoint> midpoints,
-            int numParticipants, List<Participant> rowOrder) {
-        List<MidpointScore> scored = new ArrayList<>();
-
-        for (int j = 0; j < midpoints.size(); j++) {
-            int sum = 0;
-            int[] times = new int[numParticipants];
-            for (int i = 0; i < numParticipants; i++) {
-                times[i] = timeMatrix[i][j];
-                sum += times[i];
-            }
-            double avg = sum / (double) numParticipants;
-
-            double totalDeviation = 0;
-            for (int i = 0; i < numParticipants; i++) {
-                totalDeviation += Math.abs(times[i] - avg);
-            }
-
-            scored.add(new MidpointScore(midpoints.get(j), avg, totalDeviation, times));
-        }
-
-        return scored.stream()
-                .sorted(Comparator.comparingDouble(MidpointScore::avg)
-                        .thenComparingDouble(MidpointScore::totalDeviation))
-                .findFirst()
-                .orElseThrow(() -> new RuntimeException());
-    }
-
-    private int findRowIndex(List<Participant> rowOrder, Long pid) {
-        for (int i = 0; i < rowOrder.size(); i++) {
-            if (rowOrder.get(i).getId().equals(pid)) {
-                return i;
-            }
-        }
-        throw new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND);
-    }
-
-    private double haversine(double lat1, double lon1, double lat2, double lon2) {
-        final double R = 6371.0088; // 지구 반지름 (km)
-        double dLat = Math.toRadians(lat2 - lat1);
-        double dLon = Math.toRadians(lon2 - lon1);
-        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-                Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
-                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        return R * c; // 거리 (km)
-    }
-
     private void saveRecommendedMidpoint(MidpointScore best, Meeting meeting) {
         log.info("Saving recommended midpoint: {}, average time: {}", best.midpoint().getName(),
                 best.avg());
@@ -217,10 +131,5 @@ public class TimeMatrixMidpointStrategy implements MidpointStrategy {
                 best.midpoint()
         );
         recommendedMidpointRepository.save(recommended);
-    }
-
-    private record MidpointScore(Midpoint midpoint, double avg, double totalDeviation,
-                                 int[] times) {
-
     }
 }

--- a/src/test/java/com/ODG/ODG_back/service/MidpointServiceTest.java
+++ b/src/test/java/com/ODG/ODG_back/service/MidpointServiceTest.java
@@ -1,6 +1,11 @@
 package com.ODG.ODG_back.service;
 
+import com.ODG.ODG_back.domain.Meeting;
+import com.ODG.ODG_back.domain.Midpoint;
 import com.ODG.ODG_back.dto.midpoint.response.MidpointResponseDto;
+import com.ODG.ODG_back.mapper.MidpointMapper;
+import com.ODG.ODG_back.repository.MeetingRepository;
+import com.ODG.ODG_back.repository.RecommendedMidpointRepository;
 import com.ODG.ODG_back.strategy.MidpointStrategy;
 import com.ODG.ODG_back.strategy.MidpointStrategyType;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +30,14 @@ class MidpointServiceTest {
     @Mock
     private MidpointStrategy subwayStrategy;
 
+    @Mock
+    private RecommendedMidpointRepository recommendedMidpointRepository;
+
+    @Mock
+    private MeetingRepository meetingRepository;
+
+    @Mock
+    private MidpointMapper midpointMapper;
     private MidpointService midpointService;
 
     @BeforeEach
@@ -33,7 +46,7 @@ class MidpointServiceTest {
                 "timeMatrixStrategy", timeMatrixStrategy,
                 "subwayStrategy", subwayStrategy
         );
-        midpointService = new MidpointService(strategyMap);
+        midpointService = new MidpointService(strategyMap, recommendedMidpointRepository, meetingRepository, midpointMapper);
     }
 
     @Test
@@ -42,12 +55,29 @@ class MidpointServiceTest {
         //given
         String inviteCode = "abc123";
         MidpointStrategyType strategyType = MidpointStrategyType.TIME_MATRIX;
+        Meeting meeting = new Meeting();
+        Midpoint midpoint = new Midpoint(
+                1L,
+                "광화문",
+                new BigDecimal("37.5713"),
+                new BigDecimal("126.9768"),
+                "02-123-4567",
+                10.0
+        );
+        int[] times = new int[]{10, 10, 10};
 
-        MidpointResponseDto dummyResponse = new MidpointResponseDto(
-                1L, "광화문", BigDecimal.ONE, BigDecimal.TEN
+        MidpointStrategy.MidpointScore dummyScore = new MidpointStrategy.MidpointScore(
+                midpoint,10,10,times
         );
 
-        given(timeMatrixStrategy.calculateMidpoints(inviteCode)).willReturn(dummyResponse);
+        MidpointStrategy.MidpointScoreWithMeta dummyResponse = new MidpointStrategy.MidpointScoreWithMeta(
+                dummyScore,
+                1L,
+                10,
+                3
+        );
+
+        given(timeMatrixStrategy.calculateMidpoints(meeting)).willReturn(dummyResponse);
 
         // when
         MidpointResponseDto result = midpointService.getRecommendedMidpoints(inviteCode,


### PR DESCRIPTION
**1. Midpoint - Subway Strategy의 전체적인 코드 리팩토링**
- 자동차 경로의 경우 별도로 계산이 불가능해, TimeMatrix 전략과 동일하게 Google API를 사용하는 방식으로 변경했고, 그 과정에서 전체적으로 로직 내 코드를 전체적으로 수정하였습니다.
- 지하철 경로의 경우, 기존과 동일(지하철 간 최단 이동시간 데이터 사용)하게 사용하되, 이동 시간 TimeMatrix를 생성하도록 하였습니다.


**2. MidPointStrategy 의존성 제거를 위한 리팩토링**
- 현재 코드 상에서 MidPointStrategy가 MidPointResponseDTO를 반환하고 있으나, DTO를 Service가 아닌 Strategy 단에서부터 
생성/반환하는 경우 Strategy가 API Response 반환 형식에 의존성을 가지게 됩니다.
-  이에 따른 의존성 제거를 위해 Strategy에서는 MidPointScoreWithMeta(Midpoint Score 및 현재 사용자의 시간 정보)를 반환하도록 하고, MidPointService에서 RecommendedMidPoint를 저장하고, DTO로 변환하도록 리팩토링하였습니다.

**3. 지하철 역 정보 데이터**
현재 지하철 역 간 이동 시간 데이터가 사용하는 역 ID 정보에 맞게 데이터를 가공하여 CSV 파일을 정리하였습니다.

[Book(Sheet1) (2).csv](https://github.com/user-attachments/files/22050501/Book.Sheet1.2.csv)

