### PR TITLE
Refactor/ 참가자 정보 확인 api, 투표 수 dto에 포함

### DIFF
--- a/src/main/java/com/ODG/ODG_back/controller/ParticipantController.java
+++ b/src/main/java/com/ODG/ODG_back/controller/ParticipantController.java
@@ -81,4 +81,26 @@ public class ParticipantController {
                 linkCode);
         return ResponseEntity.ok(participants);
     }
+
+    @GetMapping("/me")
+    public ResponseEntity<ParticipantListResponseDto> getMyInfo(
+            @PathVariable String linkCode,
+            Authentication auth
+    ) {
+        if (auth == null || auth.getPrincipal() == null) {
+            throw new UnauthorizedException(ErrorCode.UNAUTHORIZED);
+        }
+        String userId = (String) auth.getPrincipal();
+        ParticipantListResponseDto participant = participantService.getMyInfo(linkCode, userId);
+        return ResponseEntity.ok(participant);
+    }
+
+    @GetMapping("/{participantId}")
+    public ResponseEntity<ParticipantListResponseDto> getParticipant(
+            @PathVariable String linkCode,
+            @PathVariable Long participantId
+    ) {
+        ParticipantListResponseDto participant = participantService.getParticipant(linkCode, participantId);
+        return ResponseEntity.ok(participant);
+    }
 }

--- a/src/main/java/com/ODG/ODG_back/dto/place/response/PlaceResponseDto.java
+++ b/src/main/java/com/ODG/ODG_back/dto/place/response/PlaceResponseDto.java
@@ -21,10 +21,11 @@ public class PlaceResponseDto {
     private Integer slotNo;
     private String url;
     private boolean votedByMe = false;
+    private Integer voteCount = 0;
 
     public PlaceResponseDto(String id, String name, PlaceCategory category,
             BigDecimal lat, BigDecimal lng, String address,
-            int slotNo, String placeUrl) {
+            int slotNo, String placeUrl, int voteCount) {
         this.placeId = id;
         this.name = name;
         this.category = category;
@@ -33,6 +34,7 @@ public class PlaceResponseDto {
         this.address = address;
         this.slotNo = slotNo;
         this.url = placeUrl;
+        this.voteCount = voteCount;
     }
 
 }

--- a/src/main/java/com/ODG/ODG_back/dto/vote/response/VoteResultDto.java
+++ b/src/main/java/com/ODG/ODG_back/dto/vote/response/VoteResultDto.java
@@ -3,10 +3,15 @@ package com.ODG.ODG_back.dto.vote.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@Getter
 @AllArgsConstructor
 public class VoteResultDto {
 
+    @Getter
     private int slotNo;
     private Long voteCount;
+
+    public int getVoteCount() {
+        return voteCount.intValue();
+    }
+
 }

--- a/src/main/java/com/ODG/ODG_back/service/ParticipantService.java
+++ b/src/main/java/com/ODG/ODG_back/service/ParticipantService.java
@@ -89,4 +89,31 @@ public class ParticipantService {
                 .orElseThrow(() -> new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND));
         return participant.getId();
     }
+
+    // 단건 참가자 조회 (공개) - linkCode 범위 내에서 participantId로 조회
+    public ParticipantListResponseDto getParticipant(String linkCode, Long participantId) {
+        // 해당 모임의 참가자 목록(투표 여부 포함)을 가져온 후, id로 필터링
+        List<ParticipantListResponseDto> participants = participantRepository.findParticipantsWithVoteStatus(linkCode);
+        return participants.stream()
+                .filter(p -> p.getParticipantId().equals(participantId))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND));
+    }
+
+    // 본인 참가자 조회 (인증 필요) - linkCode + userId 기준
+    public ParticipantListResponseDto getMyInfo(String linkCode, String userId) {
+        // 먼저 모임을 확인하고, userId로 참가자 엔티티를 찾아 존재를 보장
+        Meeting meeting = meetingRepository.findByInviteCode(linkCode)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MEETING_NOT_FOUND));
+
+        Participant participant = participantRepository.findByUserIdAndMeeting(userId, meeting)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND));
+
+        // 투표 여부 포함 DTO
+        List<ParticipantListResponseDto> participants = participantRepository.findParticipantsWithVoteStatus(linkCode);
+        return participants.stream()
+                .filter(p -> p.getParticipantId().equals(participant.getId()))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(ErrorCode.PARTICIPANT_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/ODG/ODG_back/service/PlaceService.java
+++ b/src/main/java/com/ODG/ODG_back/service/PlaceService.java
@@ -132,6 +132,20 @@ public class PlaceService {
         }
         var myVoteSlotSet = new java.util.HashSet<>(myVoteSlotNos);
 
+        // 🔢 Prefetch vote counts for this meeting (slotNo -> count)
+        Map<Integer, Integer> voteCountMap = new java.util.HashMap<>();
+        try {
+            var counts = voteRepository.findVoteCountsByMeeting(meeting); // returns DTO/projection with slotNo & voteCount(Long)
+            for (var c : counts) {
+                int slot = c.getSlotNo();
+                int cnt = c.getVoteCount();
+                voteCountMap.put(slot, cnt);
+            }
+        } catch (Exception e) {
+            log.warn("[PlaceService] Failed to prefetch vote counts: {}", e.toString());
+        }
+
+
         List<PlaceSectionDto> sections = new ArrayList<>();
         if (meeting.getType() == MeetingType.SOCIAL) {
             log.info("[PlaceService] Processing SOCIAL meeting - page={}", pageLocal);
@@ -167,6 +181,10 @@ public class PlaceService {
                     for (PlaceResponseDto p : items) {
                         p.setVotedByMe(myVoteSlotNos.contains(p.getSlotNo()));
                     }
+                }
+
+                for (PlaceResponseDto p : items) {
+                    p.setVoteCount(voteCountMap.getOrDefault(p.getSlotNo(), 0));
                 }
 
                 for (PlaceResponseDto p : items) {
@@ -208,6 +226,10 @@ public class PlaceService {
                 for (PlaceResponseDto p : items) {
                     p.setVotedByMe(myVoteSlotNos.contains(p.getSlotNo()));
                 }
+            }
+
+            for (PlaceResponseDto p : items) {
+                p.setVoteCount(voteCountMap.getOrDefault(p.getSlotNo(), 0));
             }
 
             for (PlaceResponseDto p : items) {

--- a/src/main/java/com/ODG/ODG_back/service/PlaceSlotAssigner.java
+++ b/src/main/java/com/ODG/ODG_back/service/PlaceSlotAssigner.java
@@ -40,19 +40,11 @@ public class PlaceSlotAssigner {
                     doc.getAddress_name(),
                     startSlotNo + i, // ✅ 주어진 시작 슬롯부터 연속 할당
                     doc.getPlace_url(),
-                    false
+                    false,
+                    0
             ));
         }
         return items;
-    }
-
-
-    static double haversine(double lat1, double lng1, double lat2, double lng2) {
-        double R=6371000d, dLat=Math.toRadians(lat2-lat1), dLng=Math.toRadians(lng2-lng1);
-        double a=Math.sin(dLat/2)*Math.sin(dLat/2)+
-                Math.cos(Math.toRadians(lat1))*Math.cos(Math.toRadians(lat2))*
-                        Math.sin(dLng/2)*Math.sin(dLng/2);
-        return 2*R*Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
     }
 
 }

--- a/src/main/java/com/ODG/ODG_back/service/VoteService.java
+++ b/src/main/java/com/ODG/ODG_back/service/VoteService.java
@@ -122,7 +122,7 @@ public class VoteService {
             if (chosen == null) continue;
 
             // 6) DTO로 추가 (저장 X)
-            PlaceResponseDto dto = toDto(chosen, slotNo);
+            PlaceResponseDto dto = toDto(chosen, slotNo, r.getVoteCount());
             finalPlaces.add(dto);
         }
 
@@ -196,7 +196,7 @@ public class VoteService {
         return chosen;
     }
 
-    private PlaceResponseDto toDto(KakaoPlaceDoc chosen, int slotNo) {
+    private PlaceResponseDto toDto(KakaoPlaceDoc chosen, int slotNo, int voteCount) {
         if (chosen == null) return null;
         return new PlaceResponseDto(
                 chosen.getId(),
@@ -206,7 +206,8 @@ public class VoteService {
                 BigDecimal.valueOf(chosen.getX()),
                 chosen.getAddress_name(),
                 slotNo,
-                chosen.getPlace_url()
+                chosen.getPlace_url(),
+                voteCount
         );
     }
 }


### PR DESCRIPTION
1. 참가자 정보 확인 api
```
getParticipantById(linkCode, participantId)
- 특정 participantId를 기반으로 해당 모임의 참가자 정보를 반환 (공개용).
getParticipantByUserId(linkCode, userId)
- 인증된 사용자(userId)를 기반으로 본인 참가자 정보를 반환 (/me 엔드포인트용).
```
2. 투표 수 dto에 포함
- 장소 응답 DTO(PlaceResponseDto)에 득표수 voteCount 필드를 추가했습니다.
- 목록 조회 API에서도 votedByMe뿐 아니라 voteCount를 DB 집계로 보정(hydrate) 하여 반환합니다.