### PR TITLE
fix: 참가자 중복 표시되는 문제 해결

### DIFF
--- a/src/main/java/com/ODG/ODG_back/dto/participant/response/ParticipantListResponseDto.java
+++ b/src/main/java/com/ODG/ODG_back/dto/participant/response/ParticipantListResponseDto.java
@@ -15,5 +15,6 @@ public class ParticipantListResponseDto {
     private TransportType transportType;
     private BigDecimal lat;
     private BigDecimal lng;
+    private String address;
     private boolean hasVoted;
 }

--- a/src/main/java/com/ODG/ODG_back/repository/ParticipantRepository.java
+++ b/src/main/java/com/ODG/ODG_back/repository/ParticipantRepository.java
@@ -16,11 +16,21 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     Optional<Participant> findByUserId(String userId);
 
-    @Query("SELECT new com.ODG.ODG_back.dto.participant.response.ParticipantListResponseDto(p.id, p.name, p.transportType, p.latitude, p.longitude, "
-            +
-            "CASE WHEN v.participant.id IS NOT NULL THEN true ELSE false END) " +
-            "FROM Participant p LEFT JOIN Vote v ON p.id = v.participant.id " +
-            "WHERE p.meeting.inviteCode = :linkCode")
+    @Query("""
+    SELECT new com.ODG.ODG_back.dto.participant.response.ParticipantListResponseDto(
+        p.id,
+        p.name,
+        p.transportType,
+        p.latitude,
+        p.longitude,
+        p.address,
+        CASE WHEN COUNT(v.id) > 0 THEN true ELSE false END
+    )
+    FROM Participant p
+    LEFT JOIN Vote v ON v.participant.id = p.id
+    WHERE p.meeting.inviteCode = :linkCode
+    GROUP BY p.id, p.name, p.transportType, p.latitude, p.longitude
+    """)
     List<ParticipantListResponseDto> findParticipantsWithVoteStatus(
             @Param("linkCode") String linkCode);
 }


### PR DESCRIPTION
1. 참가자 조회 쿼리 수정하여 참가자 현황에서 중복으로 뜨는 현상 해결했습니다.
```
- COUNT(v.id) > 0로 투표 여부를 계산
- 참가자 컬럼들로 GROUP BY 해서 중복 행 제거
```
2. `ParticipantListDto`에서 참가자의 주소도 같이 반환하도록 수정했습니다.