### PR TITLE
fix: 참가자 정보 수정 - 위경도 반영

### DIFF
--- a/src/main/java/com/ODG/ODG_back/mapper/ParticipantUpdateMapper.java
+++ b/src/main/java/com/ODG/ODG_back/mapper/ParticipantUpdateMapper.java
@@ -9,5 +9,9 @@ import org.mapstruct.*;
 public interface ParticipantUpdateMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mappings({
+            @Mapping(source = "lat", target = "latitude"),
+            @Mapping(source = "lng", target = "longitude")
+    })
     void updateFromDto(ParticipantUpdateRequestDto dto, @MappingTarget Participant participant);
 }


### PR DESCRIPTION
1. 참가자 정보 수정 시 위경도 반영이 안되는 문제 해결하였습니다.
- `ParticipantUpdateRequestDto`의 필드 lat, lng <-> `Participant` 테이블 필드 latitude, longitude 매핑 문제 해결했습니다.
